### PR TITLE
Improve Exit to hold interruption errors

### DIFF
--- a/packages/effect/src/effect.ts
+++ b/packages/effect/src/effect.ts
@@ -938,19 +938,17 @@ export function combineInterruptExit<S, R, E, A, S2, R2, E2>(
             if (finalize._tag === "Done") {
               const errors = pipe(
                 [
-                  exit.error,
-                  ...(exit.others ? exit.others : []),
-                  ...Ar.flatten(finalize.value.map((x) => [x.error, ...(x.others ? x.others : [])]))
+                  ...(exit.errors ? exit.errors : []),
+                  ...Ar.flatten(finalize.value.map((x) => x.errors ? x.errors : []))
                 ],
                 Ar.filter((x): x is Error => x !== undefined)
               );
 
               return errors.length > 0
-                ? completed(ex.interruptWithErrorAndOthers(errors[0], Ar.dropLeft(1)(errors)))
+                ? completed(ex.withErrors(errors)(exit))
                 : completed(exit);
             } else {
-              console.warn("BUG: interrupt finalizer should not fail");
-              return completed(exit);
+              throw new Error("BUG: interrupt finalizer should not fail");
             }
           })
         : completed(exit)

--- a/packages/effect/src/exit.ts
+++ b/packages/effect/src/exit.ts
@@ -7,8 +7,7 @@ import {
   done,
   abort,
   interrupt,
-  interruptWithError,
-  interruptWithErrorAndOthers,
+  withErrors,
   Cause,
   ExitTag,
   raise
@@ -23,8 +22,7 @@ export {
   done,
   abort,
   interrupt,
-  interruptWithError,
-  interruptWithErrorAndOthers,
+  withErrors,
   Cause,
   ExitTag,
   raise
@@ -40,20 +38,20 @@ export const isInterrupt = <E, A>(e: Exit<E, A>): e is Interrupt => e._tag === "
 
 function fold_<E, A, R>(
   e: Exit<E, A>,
-  onDone: (v: A) => R,
-  onRaise: (v: E) => R,
-  onAbort: (v: unknown) => R,
-  onInterrupt: (i: Interrupt) => R
+  onDone: (v: A, errors?: Array<Error>) => R,
+  onRaise: (v: E, errors?: Array<Error>) => R,
+  onAbort: (v: unknown, errors?: Array<Error>) => R,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => R
 ) {
   switch (e._tag) {
     case "Done":
-      return onDone(e.value);
+      return onDone(e.value, e.errors);
     case "Raise":
-      return onRaise(e.error);
+      return onRaise(e.error, e.errors);
     case "Abort":
-      return onAbort(e.abortedWith);
+      return onAbort(e.abortedWith, e.errors);
     case "Interrupt":
-      return onInterrupt(e);
+      return onInterrupt(e, e.errors);
   }
 }
 
@@ -62,10 +60,10 @@ export const exit = {
 };
 
 export function fold<E, A, R>(
-  onDone: (v: A) => R,
-  onRaise: (v: E) => R,
-  onAbort: (v: unknown) => R,
-  onInterrupt: () => R
+  onDone: (v: A, errors?: Array<Error>) => R,
+  onRaise: (v: E, errors?: Array<Error>) => R,
+  onAbort: (v: unknown, errors?: Array<Error>) => R,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => R
 ): (e: Exit<E, A>) => R {
   return (e) => fold_(e, onDone, onRaise, onAbort, onInterrupt);
 }

--- a/packages/effect/src/managed.ts
+++ b/packages/effect/src/managed.ts
@@ -436,9 +436,9 @@ export function use<S, R, E, A, S2, R2, E2, B>(
   });
 }
 
-export interface Leak<S, R, E, A> {
+export interface Leak<S, E, A> {
   a: A;
-  release: T.Effect<S, R, E, unknown>;
+  release: T.Effect<S, unknown, E, unknown>;
 }
 
 /**
@@ -451,7 +451,7 @@ export interface Leak<S, R, E, A> {
  */
 export function allocate<S, R, E, A>(
   res: Managed<S, R, E, A>
-): T.Effect<S, R, E, Leak<S, R, E, A>> {
+): T.Effect<S, R, E, Leak<S, E, A>> {
   return T.accessM((r: R) => {
     const c = fromM(res)(r);
 

--- a/packages/effect/test/Interrupt.test.ts
+++ b/packages/effect/test/Interrupt.test.ts
@@ -1,6 +1,6 @@
 import { effect as T } from "../src";
 import * as assert from "assert";
-import { interruptWithError, interruptWithErrorAndOthers } from "../src/original/exit";
+import { interrupt, withErrors } from "../src/original/exit";
 import { sequenceT } from "fp-ts/lib/Apply";
 import { array } from "fp-ts/lib/Array";
 
@@ -22,7 +22,7 @@ describe("Interrupt", () => {
 
     await T.runToPromise(T.delay(T.unit, 110));
 
-    assert.deepStrictEqual(exit, interruptWithError(new Error("test error")));
+    assert.deepStrictEqual(exit, withErrors([new Error("test error")])(interrupt));
   });
 
   it("should interrupt with error parallel", async () => {
@@ -51,7 +51,7 @@ describe("Interrupt", () => {
 
     assert.deepStrictEqual(
       exit,
-      interruptWithErrorAndOthers(new Error("test error"), [new Error("test error 2")])
+      withErrors([new Error("test error"), new Error("test error 2")])(interrupt)
     );
   });
 

--- a/packages/effect/test/ParFast.test.ts
+++ b/packages/effect/test/ParFast.test.ts
@@ -1,6 +1,6 @@
 import { effect as T } from "../src";
 import { right, left } from "fp-ts/lib/Either";
-import { raise, interruptWithErrorAndOthers } from "../src/exit";
+import { raise, interrupt, withErrors } from "../src/exit";
 
 describe("ParFast", () => {
   it("should cancel", async () => {
@@ -76,7 +76,7 @@ describe("ParFast", () => {
     expect(d.mock.calls.length).toStrictEqual(1);
 
     expect(result).toStrictEqual(
-      interruptWithErrorAndOthers(new Error("a"), [new Error("b"), new Error("c"), new Error("d")])
+      withErrors([new Error("a"), new Error("b"), new Error("c"), new Error("d")])(interrupt)
     );
   });
 });

--- a/packages/prelude/src/exit.ts
+++ b/packages/prelude/src/exit.ts
@@ -12,8 +12,7 @@ import {
   done,
   abort,
   interrupt,
-  interruptWithError,
-  interruptWithErrorAndOthers,
+  withErrors,
   Cause,
   ExitTag,
   raise
@@ -28,8 +27,7 @@ export {
   done,
   abort,
   interrupt,
-  interruptWithError,
-  interruptWithErrorAndOthers,
+  withErrors,
   Cause,
   ExitTag,
   raise
@@ -45,55 +43,55 @@ export const isInterrupt = <E, A>(e: Exit<E, A>): e is Interrupt => e._tag === "
 
 function fold_<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
   e: Exit<E, A>,
-  onDone: (v: A) => T.Effect<S1, R1, E1, B1>,
-  onRaise: (v: E) => T.Effect<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => T.Effect<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => T.Effect<S4, R4, E4, B4>
+  onDone: (v: A, errors?: Array<Error>) => T.Effect<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => T.Effect<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => T.Effect<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => T.Effect<S4, R4, E4, B4>
 ): T.Effect<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 function fold_<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
   e: Exit<E, A>,
-  onDone: (v: A) => M.Managed<S1, R1, E1, B1>,
-  onRaise: (v: E) => M.Managed<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => M.Managed<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => M.Managed<S4, R4, E4, B4>
+  onDone: (v: A, errors?: Array<Error>) => M.Managed<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => M.Managed<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => M.Managed<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => M.Managed<S4, R4, E4, B4>
 ): M.Managed<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 function fold_<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
   e: Exit<E, A>,
-  onDone: (v: A) => S.Stream<S1, R1, E1, B1>,
-  onRaise: (v: E) => S.Stream<S2, R2, E2, B2>,
+  onDone: (v: A, errors?: Array<Error>) => S.Stream<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => S.Stream<S2, R2, E2, B2>,
   onAbort: (v: unknown) => S.Stream<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => S.Stream<S4, R4, E4, B4>
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => S.Stream<S4, R4, E4, B4>
 ): S.Stream<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 function fold_<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
   e: Exit<E, A>,
-  onDone: (v: A) => SE.StreamEither<S1, R1, E1, B1>,
-  onRaise: (v: E) => SE.StreamEither<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => SE.StreamEither<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => SE.StreamEither<S4, R4, E4, B4>
+  onDone: (v: A, errors?: Array<Error>) => SE.StreamEither<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => SE.StreamEither<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => SE.StreamEither<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => SE.StreamEither<S4, R4, E4, B4>
 ): SE.StreamEither<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 function fold_<E, A, B1, B2, B3, B4>(
   e: Exit<E, A>,
-  onDone: (v: A) => B1,
-  onRaise: (v: E) => B2,
-  onAbort: (v: unknown) => B3,
-  onInterrupt: (i: Interrupt) => B4
+  onDone: (v: A, errors?: Array<Error>) => B1,
+  onRaise: (v: E, errors?: Array<Error>) => B2,
+  onAbort: (v: unknown, errors?: Array<Error>) => B3,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => B4
 ): B1 | B2 | B3 | B4;
 function fold_<E, A, B>(
   e: Exit<E, A>,
-  onDone: (v: A) => B,
-  onRaise: (v: E) => B,
-  onAbort: (v: unknown) => B,
-  onInterrupt: (i: Interrupt) => B
+  onDone: (v: A, errors?: Array<Error>) => B,
+  onRaise: (v: E, errors?: Array<Error>) => B,
+  onAbort: (v: unknown, errors?: Array<Error>) => B,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => B
 ): B | B | B | B {
   switch (e._tag) {
     case "Done":
-      return onDone(e.value);
+      return onDone(e.value, e.errors);
     case "Raise":
-      return onRaise(e.error);
+      return onRaise(e.error, e.errors);
     case "Abort":
-      return onAbort(e.abortedWith);
+      return onAbort(e.abortedWith, e.errors);
     case "Interrupt":
-      return onInterrupt(e);
+      return onInterrupt(e, e.errors);
   }
 }
 
@@ -102,121 +100,125 @@ export const exit = {
 };
 
 export function fold<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onDone: (v: A) => T.Effect<S1, R1, E1, B1>,
-  onRaise: (v: E) => T.Effect<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => T.Effect<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => T.Effect<S4, R4, E4, B4>
+  onDone: (v: A, errors?: Array<Error>) => T.Effect<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => T.Effect<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => T.Effect<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => T.Effect<S4, R4, E4, B4>
 ): (
   e: Exit<E, A>
 ) => T.Effect<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function fold<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onDone: (v: A) => M.Managed<S1, R1, E1, B1>,
-  onRaise: (v: E) => M.Managed<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => M.Managed<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => M.Managed<S4, R4, E4, B4>
+  onDone: (v: A, errors?: Array<Error>) => M.Managed<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => M.Managed<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => M.Managed<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => M.Managed<S4, R4, E4, B4>
 ): (
   e: Exit<E, A>
 ) => M.Managed<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function fold<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onDone: (v: A) => S.Stream<S1, R1, E1, B1>,
-  onRaise: (v: E) => S.Stream<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => S.Stream<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => S.Stream<S4, R4, E4, B4>
+  onDone: (v: A, errors?: Array<Error>) => S.Stream<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => S.Stream<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => S.Stream<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => S.Stream<S4, R4, E4, B4>
 ): (
   e: Exit<E, A>
 ) => S.Stream<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function fold<S1, S2, S3, S4, E, A, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onDone: (v: A) => SE.StreamEither<S1, R1, E1, B1>,
-  onRaise: (v: E) => SE.StreamEither<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => SE.StreamEither<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => SE.StreamEither<S4, R4, E4, B4>
+  onDone: (v: A, errors?: Array<Error>) => SE.StreamEither<S1, R1, E1, B1>,
+  onRaise: (v: E, errors?: Array<Error>) => SE.StreamEither<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => SE.StreamEither<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => SE.StreamEither<S4, R4, E4, B4>
 ): (
   e: Exit<E, A>
 ) => SE.StreamEither<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function fold<E, A, B1, B2, B3, B4>(
-  onDone: (v: A) => B1,
-  onRaise: (v: E) => B2,
-  onAbort: (v: unknown) => B3,
-  onInterrupt: (i: Interrupt) => B4
+  onDone: (v: A, errors?: Array<Error>) => B1,
+  onRaise: (v: E, errors?: Array<Error>) => B2,
+  onAbort: (v: unknown, errors?: Array<Error>) => B3,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => B4
 ): (e: Exit<E, A>) => B1 | B2 | B3 | B4;
 export function fold<E, A, B>(
-  onDone: (v: A) => B,
-  onRaise: (v: E) => B,
-  onAbort: (v: unknown) => B,
-  onInterrupt: (i: Interrupt) => B
+  onDone: (v: A, errors?: Array<Error>) => B,
+  onRaise: (v: E, errors?: Array<Error>) => B,
+  onAbort: (v: unknown, errors?: Array<Error>) => B,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => B
 ): (e: Exit<E, A>) => B {
   return (e) => fold_(e, onDone, onRaise, onAbort, onInterrupt);
 }
 
 export function foldExit<S1, S2, R1, R2, E, E1, E2, A, B1, B2>(
-  onCause: (v: Cause<E>) => SE.StreamEither<S2, R2, E2, B2>,
-  onDone: (v: A) => SE.StreamEither<S1, R1, E1, B1>
+  onCause: (v: Cause<E>, errors?: Array<Error>) => SE.StreamEither<S2, R2, E2, B2>,
+  onDone: (v: A, errors?: Array<Error>) => SE.StreamEither<S1, R1, E1, B1>
 ): (e: Exit<E, A>) => SE.StreamEither<S1 | S2, R1 & R2, E1 | E2, B1 | B2>;
 export function foldExit<S1, S2, R1, R2, E, E1, E2, A, B1, B2>(
-  onCause: (v: Cause<E>) => S.Stream<S2, R2, E2, B2>,
-  onDone: (v: A) => S.Stream<S1, R1, E1, B1>
+  onCause: (v: Cause<E>, errors?: Array<Error>) => S.Stream<S2, R2, E2, B2>,
+  onDone: (v: A, errors?: Array<Error>) => S.Stream<S1, R1, E1, B1>
 ): (e: Exit<E, A>) => S.Stream<S1 | S2, R1 & R2, E1 | E2, B1 | B2>;
 export function foldExit<S1, S2, R1, R2, E, E1, E2, A, B1, B2>(
-  onCause: (v: Cause<E>) => M.Managed<S2, R2, E2, B2>,
-  onDone: (v: A) => M.Managed<S1, R1, E1, B1>
+  onCause: (v: Cause<E>, errors?: Array<Error>) => M.Managed<S2, R2, E2, B2>,
+  onDone: (v: A, errors?: Array<Error>) => M.Managed<S1, R1, E1, B1>
 ): (e: Exit<E, A>) => M.Managed<S1 | S2, R1 & R2, E1 | E2, B1 | B2>;
 export function foldExit<S1, S2, R1, R2, E, E1, E2, A, B1, B2>(
-  onCause: (v: Cause<E>) => T.Effect<S2, R2, E2, B2>,
-  onDone: (v: A) => T.Effect<S1, R1, E1, B1>
+  onCause: (v: Cause<E>, errors?: Array<Error>) => T.Effect<S2, R2, E2, B2>,
+  onDone: (v: A, errors?: Array<Error>) => T.Effect<S1, R1, E1, B1>
 ): (e: Exit<E, A>) => T.Effect<S1 | S2, R1 & R2, E1 | E2, B1 | B2>;
 export function foldExit<E, A, B1, B2>(
-  onCause: (v: Cause<E>) => B2,
-  onDone: (v: A) => B1
+  onCause: (v: Cause<E>, errors?: Array<Error>) => B2,
+  onDone: (v: A, errors?: Array<Error>) => B1
 ): (e: Exit<E, A>) => B1 | B2;
 export function foldExit<E, A, B1, B2>(
-  onCause: (v: Cause<E>) => B2,
-  onDone: (v: A) => B1
+  onCause: (v: Cause<E>, errors?: Array<Error>) => B2,
+  onDone: (v: A, errors?: Array<Error>) => B1
 ): (e: Exit<E, A>) => B1 | B2;
 export function foldExit<E, A, B>(
-  onCause: (v: Cause<E>) => B,
-  onDone: (v: A) => B
+  onCause: (v: Cause<E>, errors?: Array<Error>) => B,
+  onDone: (v: A, errors?: Array<Error>) => B
 ): (e: Exit<E, A>) => B {
-  return (e) => (isDone(e) ? onDone(e.value) : onCause(e));
+  return (e) => (isDone(e) ? onDone(e.value, e.errors) : onCause(e, e.errors));
 }
 
 export function foldCause<S1, S2, S3, S4, E, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onRaise: (v: E) => T.Effect<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => T.Effect<S3, R3, E3, B3>,
+  onRaise: (v: E, errors?: Array<Error>) => T.Effect<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => T.Effect<S3, R3, E3, B3>,
   onInterrupt: (i: Interrupt) => T.Effect<S4, R4, E4, B4>
 ): (
   e: Cause<E>
 ) => T.Effect<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function foldCause<S1, S2, S3, S4, E, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onRaise: (v: E) => M.Managed<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => M.Managed<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => M.Managed<S4, R4, E4, B4>
+  onRaise: (v: E, errors?: Array<Error>) => M.Managed<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => M.Managed<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => M.Managed<S4, R4, E4, B4>
 ): (
   e: Cause<E>
 ) => M.Managed<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function foldCause<S1, S2, S3, S4, E, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onRaise: (v: E) => S.Stream<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => S.Stream<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => S.Stream<S4, R4, E4, B4>
+  onRaise: (v: E, errors?: Array<Error>) => S.Stream<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => S.Stream<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => S.Stream<S4, R4, E4, B4>
 ): (
   e: Cause<E>
 ) => S.Stream<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function foldCause<S1, S2, S3, S4, E, B1, B2, B3, B4, R1, E1, R2, E2, R3, E3, R4, E4>(
-  onRaise: (v: E) => SE.StreamEither<S2, R2, E2, B2>,
-  onAbort: (v: unknown) => SE.StreamEither<S3, R3, E3, B3>,
-  onInterrupt: (i: Interrupt) => SE.StreamEither<S4, R4, E4, B4>
+  onRaise: (v: E, errors?: Array<Error>) => SE.StreamEither<S2, R2, E2, B2>,
+  onAbort: (v: unknown, errors?: Array<Error>) => SE.StreamEither<S3, R3, E3, B3>,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => SE.StreamEither<S4, R4, E4, B4>
 ): (
   e: Cause<E>
 ) => SE.StreamEither<S1 | S2 | S3 | S4, R1 & R2 & R3 & R4, E1 | E2 | E3 | E4, B1 | B2 | B3 | B4>;
 export function foldCause<E, B1, B2, B3, B4>(
-  onRaise: (v: E) => B2,
-  onAbort: (v: unknown) => B3,
-  onInterrupt: (i: Interrupt) => B4
+  onRaise: (v: E, errors?: Array<Error>) => B2,
+  onAbort: (v: unknown, errors?: Array<Error>) => B3,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => B4
 ): (e: Cause<E>) => B1 | B2 | B3 | B4;
 export function foldCause<E, B>(
-  onRaise: (v: E) => B,
-  onAbort: (v: unknown) => B,
-  onInterrupt: (i: Interrupt) => B
+  onRaise: (v: E, errors?: Array<Error>) => B,
+  onAbort: (v: unknown, errors?: Array<Error>) => B,
+  onInterrupt: (i: Interrupt, errors?: Array<Error>) => B
 ): (e: Cause<E>) => B {
   return (e) =>
-    isRaise(e) ? onRaise(e.error) : isAbort(e) ? onAbort(e.abortedWith) : onInterrupt(e);
+    isRaise(e)
+      ? onRaise(e.error, e.errors)
+      : isAbort(e)
+      ? onAbort(e.abortedWith, e.errors)
+      : onInterrupt(e, e.errors);
 }


### PR DESCRIPTION
Why?

We have many cases like for example raceFirst where we interrupt "other" computations and get correct exit results, those were written before interruption was async & failable and in the current implementation interruption errors are silently ignored.

This PR adds a optional field "errors" in all exit status so we can preserve those errors