### PR TITLE
Enstablish Compatibility With fp-ts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "fp-ts": "2.6.2",
-    "io-ts": "2.2.4"
+    "io-ts": "2.2.4",
+    "fp-ts-contrib": "^0.1.15"
   },
   "gitHead": "2ff0a2daa194950901aba13f3431b2470889f9c2"
 }

--- a/packages/core/src/Array/index.ts
+++ b/packages/core/src/Array/index.ts
@@ -28,7 +28,19 @@ import type {
   Traverse1,
   TraverseWithIndex1,
   Wither1,
-  Wilt1
+  Wilt1,
+  Monad1,
+  Foldable1,
+  Unfoldable1,
+  TraversableWithIndex1,
+  Alternative1,
+  Extend1,
+  Compactable1,
+  FilterableWithIndex1,
+  Witherable1,
+  FunctorWithIndex1,
+  FoldableWithIndex1,
+  Applicative1
 } from "../Base"
 import { Do as DoG } from "../Do"
 import type { Either } from "../Either"
@@ -1350,3 +1362,26 @@ export const sequenceS =
 export const sequenceT =
   /*#__PURE__*/
   (() => AP.sequenceT(arrayAp))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const array_: Monad1<URI> &
+  Foldable1<URI> &
+  Unfoldable1<URI> &
+  TraversableWithIndex1<URI, number> &
+  Alternative1<URI> &
+  Extend1<URI> &
+  Compactable1<URI> &
+  FilterableWithIndex1<URI, number> &
+  Witherable1<URI> &
+  FunctorWithIndex1<URI, number> &
+  FoldableWithIndex1<URI, number> &
+  Applicative1<URI> =
+  /*#__PURE__*/
+  (() =>
+    ({
+      ...RA.readonlyArray_,
+      URI
+    } as any))()

--- a/packages/core/src/Base/Apply/index.ts
+++ b/packages/core/src/Base/Apply/index.ts
@@ -1,5 +1,9 @@
 /* adapted from https://github.com/gcanti/fp-ts */
 
+export { sequenceS as sequenceS_, sequenceT as sequenceT_ } from "fp-ts/lib/Apply"
+
+import type { URI as EitherURI } from "../../Either"
+import type { Apply2M } from "../../Either/overloads"
 import { tuple } from "../../Function"
 import type { GE } from "../../Utils"
 import type {
@@ -137,6 +141,21 @@ export type SOf<R extends Record<string, GE<any, any, any, any>>> = {
   [K in keyof R]: STypeOf<R[K]>
 }[keyof R]
 
+export function sequenceT<F extends EitherURI>(
+  F: Apply2M<F>
+): <Z extends Array<Kind2<F, any, any>>>(
+  ...t: Z & {
+    readonly 0: Kind2<F, any, any>
+  }
+) => Kind2<
+  F,
+  {
+    [K in keyof Z]: Z[K] extends Kind2<F, infer _E, infer _A> ? _E : never
+  }[number],
+  {
+    [K in keyof Z]: Z[K] extends Kind2<F, infer _E, infer _A> ? _A : never
+  }[number]
+>
 export function sequenceT<F extends MaURIS>(
   F: CApply4MAP<F>
 ): <T extends Array<Kind4<F, any, any, any, any>>>(
@@ -317,6 +336,19 @@ function getRecordConstructor(keys: ReadonlyArray<string>) {
   )
 }
 
+export function sequenceS<F extends EitherURI>(
+  F: Apply2M<F>
+): <NER extends Record<string, Kind2<F, any, any>>>(
+  r: EnforceNonEmptyRecord<NER> & Record<string, Kind2<F, any, any>>
+) => Kind2<
+  F,
+  {
+    [K in keyof NER]: [NER[K]] extends [Kind2<F, infer _E, infer _A>] ? _E : never
+  }[keyof NER],
+  {
+    [K in keyof NER]: [NER[K]] extends [Kind2<F, infer _E, infer _A>] ? _A : never
+  }
+>
 export function sequenceS<F extends MaURIS>(
   F: CApply4MA<F>
 ): <NER extends Record<string, Kind4<F, any, any, any, any>>>(

--- a/packages/core/src/Base/Filterable/index.ts
+++ b/packages/core/src/Base/Filterable/index.ts
@@ -50,6 +50,11 @@ export interface CFilter1<F extends URIS> {
   <A>(predicate: Predicate<A>): (fa: Kind<F, A>) => Kind<F, A>
 }
 
+export interface Filter1<F extends URIS> {
+  <A, B extends A>(fa: Kind<F, A>, refinement: Refinement<A, B>): Kind<F, B>
+  <A>(fa: Kind<F, A>, predicate: Predicate<A>): Kind<F, A>
+}
+
 export interface CPartition1<F extends URIS> {
   <A, B extends A>(refinement: Refinement<A, B>): (
     fa: Kind<F, A>

--- a/packages/core/src/Base/HKT/index.ts
+++ b/packages/core/src/Base/HKT/index.ts
@@ -14,11 +14,7 @@ import type {
   URIS,
   URIS2,
   URIS3,
-  URIS4,
-  URItoKind,
-  URItoKind2,
-  URItoKind3,
-  URItoKind4
+  URIS4
 } from "fp-ts/lib/HKT"
 
 import type {
@@ -31,6 +27,11 @@ import type {
   StreamEither,
   StreamEitherURI
 } from "../../Support/Common"
+
+export interface URItoKind<A> {}
+export interface URItoKind2<E, A> {}
+export interface URItoKind3<R, E, A> {}
+export interface URItoKind4<S, R, E, A> extends MaToKind<S, R, E, A> {}
 
 declare module "fp-ts/lib/HKT" {
   interface URItoKind4<S, R, E, A> extends MaToKind<S, R, E, A> {}
@@ -48,21 +49,4 @@ export interface MaToKind<S, R, E, A> {
  */
 export type MaURIS = keyof MaToKind<any, any, any, any>
 
-export {
-  HKT,
-  HKT2,
-  HKT3,
-  HKT4,
-  Kind,
-  Kind2,
-  Kind3,
-  Kind4,
-  URIS,
-  URIS2,
-  URIS3,
-  URIS4,
-  URItoKind,
-  URItoKind2,
-  URItoKind3,
-  URItoKind4
-}
+export { HKT, HKT2, HKT3, HKT4, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 }

--- a/packages/core/src/Base/HKT/index.ts
+++ b/packages/core/src/Base/HKT/index.ts
@@ -3,6 +3,25 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import type {
+  HKT,
+  HKT2,
+  HKT3,
+  HKT4,
+  Kind,
+  Kind2,
+  Kind3,
+  Kind4,
+  URIS,
+  URIS2,
+  URIS3,
+  URIS4,
+  URItoKind,
+  URItoKind2,
+  URItoKind3,
+  URItoKind4
+} from "fp-ts/lib/HKT"
+
+import type {
   EffectURI,
   Effect,
   Managed,
@@ -13,10 +32,9 @@ import type {
   StreamEitherURI
 } from "../../Support/Common"
 
-export interface URItoKind<A> {}
-export interface URItoKind2<E, A> {}
-export interface URItoKind3<R, E, A> {}
-export interface URItoKind4<S, R, E, A> extends MaToKind<S, R, E, A> {}
+declare module "fp-ts/lib/HKT" {
+  interface URItoKind4<S, R, E, A> extends MaToKind<S, R, E, A> {}
+}
 
 export interface MaToKind<S, R, E, A> {
   [EffectURI]: Effect<S, R, E, A>
@@ -26,101 +44,25 @@ export interface MaToKind<S, R, E, A> {
 }
 
 /**
- * `* -> *` constructors
- */
-export interface HKT<URI, A> {
-  readonly _URI: URI
-  readonly _A: A
-}
-
-/**
- * `* -> * -> *` constructors
- */
-export interface HKT2<URI, E, A> extends HKT<URI, A> {
-  readonly _E: E
-}
-
-/**
- * `* -> * -> * -> *` constructors
- */
-export interface HKT3<URI, R, E, A> extends HKT2<URI, E, A> {
-  readonly _R: R
-}
-
-/**
- * `* -> * -> * -> * -> *` constructors
- */
-export interface HKT4<URI, S, R, E, A> extends HKT3<URI, R, E, A> {
-  readonly _S: S
-}
-
-/**
- * `* -> *` constructors
- */
-export interface URItoKind<A> {}
-
-/**
- * `* -> * -> *` constructors
- */
-export interface URItoKind2<E, A> {}
-
-/**
- * `* -> * -> * -> *` constructors
- */
-export interface URItoKind3<R, E, A> {}
-
-/**
- * `* -> * -> * -> * -> *` constructors
- */
-export interface URItoKind4<S, R, E, A> {}
-
-/**
- * `* -> *` constructors
- */
-export type URIS = keyof URItoKind<any>
-
-/**
- * `* -> * -> *` constructors
- */
-export type URIS2 = keyof URItoKind2<any, any>
-
-/**
- * `* -> * -> * -> *` constructors
- */
-export type URIS3 = keyof URItoKind3<any, any, any>
-
-/**
- * `* -> * -> * -> * -> *` constructors
- */
-export type URIS4 = keyof URItoKind4<any, any, any, any>
-
-/**
  * `* -> * -> * -> * -> *` constructors restricted to MaTypes (behaviourally different)
  */
 export type MaURIS = keyof MaToKind<any, any, any, any>
 
-/**
- * `* -> *` constructors
- */
-export type Kind<URI extends URIS, A> = URI extends URIS ? URItoKind<A>[URI] : any
-
-/**
- * `* -> * -> *` constructors
- */
-export type Kind2<URI extends URIS2, E, A> = URI extends URIS2
-  ? URItoKind2<E, A>[URI]
-  : any
-
-/**
- * `* -> * -> * -> *` constructors
- */
-export type Kind3<URI extends URIS3, R, E, A> = URI extends URIS3
-  ? URItoKind3<R, E, A>[URI]
-  : any
-
-/**
- * `* -> * -> * -> * -> *` constructors
- */
-export type Kind4<URI extends URIS4, S, R, E, A> = URI extends URIS4
-  ? URItoKind4<S, R, E, A>[URI]
-  : any
+export {
+  HKT,
+  HKT2,
+  HKT3,
+  HKT4,
+  Kind,
+  Kind2,
+  Kind3,
+  Kind4,
+  URIS,
+  URIS2,
+  URIS3,
+  URIS4,
+  URItoKind,
+  URItoKind2,
+  URItoKind3,
+  URItoKind4
+}

--- a/packages/core/src/Base/HKT/index.ts
+++ b/packages/core/src/Base/HKT/index.ts
@@ -49,4 +49,17 @@ export interface MaToKind<S, R, E, A> {
  */
 export type MaURIS = keyof MaToKind<any, any, any, any>
 
-export { HKT, HKT2, HKT3, HKT4, Kind, Kind2, Kind3, Kind4, URIS, URIS2, URIS3, URIS4 }
+export type {
+  HKT,
+  HKT2,
+  HKT3,
+  HKT4,
+  Kind,
+  Kind2,
+  Kind3,
+  Kind4,
+  URIS,
+  URIS2,
+  URIS3,
+  URIS4
+}

--- a/packages/core/src/Base/Overloads/index.ts
+++ b/packages/core/src/Base/Overloads/index.ts
@@ -1,0 +1,762 @@
+import type {} from "fp-ts-contrib/lib/Do"
+import type { Bifunctor4 } from "fp-ts/lib/Bifunctor"
+import type { Compactable4, Separated } from "fp-ts/lib/Compactable"
+import type { Contravariant4 } from "fp-ts/lib/Contravariant"
+import type { Either } from "fp-ts/lib/Either"
+import type { Extend4 } from "fp-ts/lib/Extend"
+import type { Filterable4 } from "fp-ts/lib/Filterable"
+import type { FilterableWithIndex4 } from "fp-ts/lib/FilterableWithIndex"
+import type { Foldable4 } from "fp-ts/lib/Foldable"
+import type { FoldableWithIndex4 } from "fp-ts/lib/FoldableWithIndex"
+import type { Functor4 } from "fp-ts/lib/Functor"
+import type { FunctorWithIndex4 } from "fp-ts/lib/FunctorWithIndex"
+import type { Kind, Kind2, Kind4, URIS, URIS2 } from "fp-ts/lib/HKT"
+import type { Option } from "fp-ts/lib/Option"
+import type { Profunctor4 } from "fp-ts/lib/Profunctor"
+import type { Semigroupoid4 } from "fp-ts/lib/Semigroupoid"
+import type { PipeableFunctor4 } from "fp-ts/lib/pipeable"
+
+import type { Predicate, Refinement } from "../../Function"
+import type { GE } from "../../Utils"
+import { MaURIS } from "../HKT"
+
+export interface Apply4E<F extends MaURIS> extends Functor4<F> {
+  readonly ap: <S1, S2, R, E, A, B, R2, E2>(
+    fab: Kind4<F, S1, R, E, (a: A) => B>,
+    fa: Kind4<F, S2, R2, E2, A>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, B>
+}
+
+export interface Apply4EP<F extends MaURIS> extends Functor4<F> {
+  _CTX: "async"
+  readonly ap: <S1, S2, R, E, A, B, R2, E2>(
+    fab: Kind4<F, S1, R, E, (a: A) => B>,
+    fa: Kind4<F, S2, R2, E2, A>
+  ) => Kind4<F, unknown, R & R2, E | E2, B> // unknown => parallel => async
+}
+
+export interface Chain4E<F extends MaURIS> extends Apply4E<F> {
+  readonly chain: <S1, S2, R, E, A, R2, E2, B>(
+    fa: Kind4<F, S1, R, E, A>,
+    f: (a: A) => Kind4<F, S2, R2, E2, B>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, B>
+}
+
+export interface Chain4EP<F extends MaURIS> extends Apply4EP<F> {
+  readonly chain: <S1, S2, R, E, A, R2, E2, B>(
+    fa: Kind4<F, S1, R, E, A>,
+    f: (a: A) => Kind4<F, S2, R2, E2, B>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, B>
+}
+
+export interface Applicative4E<F extends MaURIS> extends Apply4E<F> {
+  readonly of: <A>(a: A) => Kind4<F, never, unknown, never, A>
+}
+
+export interface Applicative4EP<F extends MaURIS> extends Apply4EP<F> {
+  readonly of: <A>(a: A) => Kind4<F, never, unknown, never, A>
+}
+
+export interface Alt4E<F extends MaURIS> extends Functor4<F> {
+  readonly alt: <S1, S2, R, R2, E, E2, A, B>(
+    fx: Kind4<F, S1, R, E, A>,
+    fy: () => Kind4<F, S2, R2, E2, B>
+  ) => Kind4<F, S1 | S2, R & R2, E2, A | B>
+}
+
+export interface Monad4E<M extends MaURIS> extends Applicative4E<M>, Chain4E<M> {}
+export interface Monad4EP<M extends MaURIS> extends Applicative4EP<M>, Chain4EP<M> {}
+export interface Monad4EC<M extends MaURIS, E>
+  extends Applicative4EC<M, E>,
+    Chain4EC<M, E> {}
+export interface Monad4ECP<M extends MaURIS, E>
+  extends Applicative4ECP<M, E>,
+    Chain4ECP<M, E> {}
+
+export interface Applicative4EC<F extends MaURIS, E> extends Apply4EC<F, E> {
+  readonly of: <A>(a: A) => Kind4<F, never, unknown, E, A>
+}
+
+export interface Applicative4ECP<F extends MaURIS, E> extends Apply4ECP<F, E> {
+  readonly of: <A>(a: A) => Kind4<F, never, unknown, E, A>
+}
+
+export interface Apply4EC<F extends MaURIS, E> extends Functor4EC<F, E> {
+  readonly ap: <S1, S2, R, R2, A, B>(
+    fab: Kind4<F, S1, R, E, (a: A) => B>,
+    fa: Kind4<F, S2, R2, E, A>
+  ) => Kind4<F, S1 | S2, R & R2, E, B>
+}
+
+export interface Apply4ECP<F extends MaURIS, E> extends Functor4EC<F, E> {
+  _CTX: "async"
+  readonly ap: <S1, S2, R, R2, A, B>(
+    fab: Kind4<F, S1, R, E, (a: A) => B>,
+    fa: Kind4<F, S2, R2, E, A>
+  ) => Kind4<F, unknown, R & R2, E, B>
+}
+
+export interface Chain4EC<F extends MaURIS, E> extends Apply4EC<F, E> {
+  readonly chain: <S1, S2, R, A, R2, B>(
+    fa: Kind4<F, S1, R, E, A>,
+    f: (a: A) => Kind4<F, S2, R2, E, B>
+  ) => Kind4<F, S1 | S2, R & R2, E, B>
+}
+
+export interface Chain4ECP<F extends MaURIS, E> extends Apply4ECP<F, E> {
+  readonly chain: <S1, S2, R, A, R2, B>(
+    fa: Kind4<F, S1, R, E, A>,
+    f: (a: A) => Kind4<F, S2, R2, E, B>
+  ) => Kind4<F, S1 | S2, R & R2, E, B>
+}
+
+export interface Functor4EC<F extends MaURIS, E> {
+  readonly URI: F
+  readonly _E: E
+  readonly map: <S, R, A, B>(
+    fa: Kind4<F, S, R, E, A>,
+    f: (a: A) => B
+  ) => Kind4<F, S, R, E, B>
+}
+
+declare type EnforceNonEmptyRecord<R> = keyof R extends never ? never : R
+
+export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never
+
+export type STypeOf<X> = X extends GE<infer _S, infer _R, infer _E, infer _A>
+  ? _S
+  : never
+
+export type ATypeOf<X> = X extends GE<infer _S, infer _R, infer _E, infer _A>
+  ? _A
+  : never
+
+export type ETypeOf<X> = X extends GE<infer _S, infer _R, infer _E, infer _A>
+  ? _E
+  : never
+
+export type RTypeOf<X> = X extends GE<infer _S, infer _R, infer _E, infer _A>
+  ? _R
+  : never
+
+export type EnvOf<
+  R extends Record<string, GE<any, any, any, any>>
+> = UnionToIntersection<
+  {
+    [K in keyof R]: unknown extends RTypeOf<R[K]> ? never : RTypeOf<R[K]>
+  }[keyof R]
+>
+
+export type SOf<R extends Record<string, GE<any, any, any, any>>> = {
+  [K in keyof R]: STypeOf<R[K]>
+}[keyof R]
+
+export interface Do4CE<M extends MaURIS, Q, S extends object, U, L> {
+  do: <Q1, E, R>(ma: Kind4<M, Q1, R, E, unknown>) => Do4CE<M, Q | Q1, S, U & R, L | E>
+  doL: <Q1, E, R>(
+    f: (s: S) => Kind4<M, Q1, R, E, unknown>
+  ) => Do4CE<M, Q | Q1, S, U & R, L | E>
+  bind: <N extends string, Q1, E, R, A>(
+    name: Exclude<N, keyof S>,
+    ma: Kind4<M, Q1, R, E, A>
+  ) => Do4CE<M, Q | Q1, S & { [K in N]: A }, U & R, L | E>
+  bindL: <N extends string, Q1, E, R, A>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => Kind4<M, Q1, R, E, A>
+  ) => Do4CE<M, Q | Q1, S & { [K in N]: A }, U & R, L | E>
+  let: <N extends string, A>(
+    name: Exclude<N, keyof S>,
+    a: A
+  ) => Do4CE<M, Q, S & { [K in N]: A }, U, L>
+  letL: <N extends string, A>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => A
+  ) => Do4CE<M, Q, S & { [K in N]: A }, U, L>
+  sequenceS: <R extends Record<string, Kind4<M, any, any, any, any>>>(
+    r: EnforceNonEmptyRecord<R> & { [K in keyof S]?: never }
+  ) => Do4CE<
+    M,
+    SOf<R> | Q,
+    S & { [K in keyof R]: ATypeOf<R[K]> },
+    U & EnvOf<R>,
+    L | ETypeOf<R[keyof R]>
+  >
+  sequenceSL: <R extends Record<string, Kind4<M, any, any, any, any>>>(
+    f: (s: S) => EnforceNonEmptyRecord<R> & { [K in keyof S]?: never }
+  ) => Do4CE<
+    M,
+    SOf<R> | Q,
+    S & { [K in keyof R]: ATypeOf<R[K]> },
+    U & EnvOf<R>,
+    L | ETypeOf<R[keyof R]>
+  >
+  return: <A>(f: (s: S) => A) => Kind4<M, Q, U, L, A>
+  done: () => Kind4<M, Q, U, L, S>
+}
+
+// eslint-disable-next-line @typescript-eslint/class-name-casing
+export interface Do4CE_<M extends MaURIS, Q, S extends object, U, L> {
+  do: <Q1, R>(ma: Kind4<M, Q1, R, L, unknown>) => Do4CE_<M, Q | Q1, S, U & R, L>
+  doL: <Q1, R>(
+    f: (s: S) => Kind4<M, Q1, R, L, unknown>
+  ) => Do4CE_<M, Q | Q1, S, U & R, L>
+  bind: <N extends string, Q1, R, A>(
+    name: Exclude<N, keyof S>,
+    ma: Kind4<M, Q1, R, L, A>
+  ) => Do4CE_<M, Q | Q1, S & { [K in N]: A }, U & R, L>
+  bindL: <N extends string, Q1, R, A>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => Kind4<M, Q1, R, L, A>
+  ) => Do4CE_<M, Q | Q1, S & { [K in N]: A }, U & R, L>
+  let: <N extends string, A>(
+    name: Exclude<N, keyof S>,
+    a: A
+  ) => Do4CE<M, Q, S & { [K in N]: A }, U, L>
+  letL: <N extends string, A>(
+    name: Exclude<N, keyof S>,
+    f: (s: S) => A
+  ) => Do4CE<M, Q, S & { [K in N]: A }, U, L>
+  sequenceS: <R extends Record<string, Kind4<M, any, any, L, any>>>(
+    r: EnforceNonEmptyRecord<R> & { [K in keyof S]?: never }
+  ) => Do4CE_<M, SOf<R> | Q, S & { [K in keyof R]: ATypeOf<R[K]> }, U & EnvOf<R>, L>
+  sequenceSL: <R extends Record<string, Kind4<M, any, any, L, any>>>(
+    f: (s: S) => EnforceNonEmptyRecord<R> & { [K in keyof S]?: never }
+  ) => Do4CE_<M, SOf<R> | Q, S & { [K in keyof R]: ATypeOf<R[K]> }, U & EnvOf<R>, L>
+  return: <A>(f: (s: S) => A) => Kind4<M, Q, U, L, A>
+  done: () => Kind4<M, Q, U, L, S>
+}
+
+declare module "fp-ts-contrib/lib/Do" {
+  export function Do<M extends MaURIS>(
+    M: Monad4E<M>
+  ): Do4CE<M, never, {}, unknown, never>
+  export function Do<M extends MaURIS>(
+    M: Monad4EP<M>
+  ): Do4CE<M, unknown, {}, unknown, never>
+  export function Do<M extends MaURIS, E>(
+    M: Monad4EC<M, E>
+  ): Do4CE_<M, never, {}, unknown, E>
+  export function Do<M extends MaURIS, E>(
+    M: Monad4ECP<M, E>
+  ): Do4CE_<M, unknown, {}, unknown, E>
+}
+
+declare module "fp-ts/lib/Apply" {
+  export function sequenceS<F extends MaURIS>(
+    F: Apply4E<F>
+  ): <NER extends Record<string, Kind4<F, any, any, any, any>>>(
+    r: EnforceNonEmptyRecord<NER> & Record<string, Kind4<F, any, any, any, any>>
+  ) => Kind4<
+    F,
+    SOf<NER>,
+    EnvOf<NER>,
+    {
+      [K in keyof NER]: [NER[K]] extends [Kind4<F, any, any, infer E, any>] ? E : never
+    }[keyof NER],
+    {
+      [K in keyof NER]: [NER[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+
+  export function sequenceS<F extends MaURIS, E>(
+    F: Apply4ECP<F, E>
+  ): <NER extends Record<string, Kind4<F, any, any, E, any>>>(
+    r: EnforceNonEmptyRecord<NER> & Record<string, Kind4<F, any, any, E, any>>
+  ) => Kind4<
+    F,
+    unknown,
+    EnvOf<NER>,
+    E,
+    {
+      [K in keyof NER]: [NER[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+
+  export function sequenceS<F extends MaURIS, E>(
+    F: Apply4EC<F, E>
+  ): <NER extends Record<string, Kind4<F, any, any, E, any>>>(
+    r: EnforceNonEmptyRecord<NER> & Record<string, Kind4<F, any, any, E, any>>
+  ) => Kind4<
+    F,
+    SOf<NER>,
+    EnvOf<NER>,
+    E,
+    {
+      [K in keyof NER]: [NER[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+
+  export function sequenceS<F extends MaURIS>(
+    F: Apply4EP<F>
+  ): <NER extends Record<string, Kind4<F, any, any, any, any>>>(
+    r: EnforceNonEmptyRecord<NER> & Record<string, Kind4<F, any, any, any, any>>
+  ) => Kind4<
+    F,
+    unknown,
+    EnvOf<NER>,
+    {
+      [K in keyof NER]: [NER[K]] extends [Kind4<F, any, any, infer E, any>] ? E : never
+    }[keyof NER],
+    {
+      [K in keyof NER]: [NER[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+
+  export function sequenceT<F extends MaURIS>(
+    F: Apply4EP<F>
+  ): <T extends Array<Kind4<F, any, any, any, any>>>(
+    ...t: T & {
+      0: Kind4<F, any, any, any, any>
+    }
+  ) => Kind4<
+    F,
+    unknown,
+    UnionToIntersection<
+      {
+        [K in keyof T]: [T[K]] extends [Kind4<F, any, infer R, any, any>]
+          ? unknown extends R
+            ? never
+            : R
+          : never
+      }[number]
+    >,
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, any, any, infer E, any>] ? E : never
+    }[number],
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+
+  export function sequenceT<F extends MaURIS>(
+    F: Apply4E<F>
+  ): <T extends Array<Kind4<F, any, any, any, any>>>(
+    ...t: T & {
+      0: Kind4<F, any, any, any, any>
+    }
+  ) => Kind4<
+    F,
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, infer S, any, any, any>] ? S : never
+    }[number],
+    UnionToIntersection<
+      {
+        [K in keyof T]: [T[K]] extends [Kind4<F, any, infer R, any, any>]
+          ? unknown extends R
+            ? never
+            : R
+          : never
+      }[number]
+    >,
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, any, any, infer E, any>] ? E : never
+    }[number],
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+
+  export function sequenceT<F extends MaURIS, E>(
+    F: Apply4ECP<F, E>
+  ): <T extends Array<Kind4<F, any, any, E, any>>>(
+    ...t: T & {
+      0: Kind4<F, any, any, E, any>
+    }
+  ) => Kind4<
+    F,
+    unknown,
+    UnionToIntersection<
+      {
+        [K in keyof T]: [T[K]] extends [Kind4<F, any, infer R, any, any>]
+          ? unknown extends R
+            ? never
+            : R
+          : never
+      }[number]
+    >,
+    E,
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+
+  export function sequenceT<F extends MaURIS, E>(
+    F: Apply4EC<F, E>
+  ): <T extends Array<Kind4<F, any, any, E, any>>>(
+    ...t: T & {
+      0: Kind4<F, any, any, E, any>
+    }
+  ) => Kind4<
+    F,
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, infer S, any, any, any>] ? S : never
+    }[number],
+    UnionToIntersection<
+      {
+        [K in keyof T]: [T[K]] extends [Kind4<F, any, infer R, any, any>]
+          ? unknown extends R
+            ? never
+            : R
+          : never
+      }[number]
+    >,
+    E,
+    {
+      [K in keyof T]: [T[K]] extends [Kind4<F, any, any, any, infer A>] ? A : never
+    }
+  >
+}
+
+export interface PipeableChain4E<F extends MaURIS> extends PipeableApply4E<F> {
+  readonly chain: <S1, R, E, A, B>(
+    f: (a: A) => Kind4<F, S1, R, E, B>
+  ) => <S2, R2, E2>(ma: Kind4<F, S2, R2, E2, A>) => Kind4<F, S1 | S2, R & R2, E | E2, B>
+  readonly chainFirst: <S1, R, E, A, B>(
+    f: (a: A) => Kind4<F, S1, R, E, B>
+  ) => <S2, R2, E2>(ma: Kind4<F, S2, R2, E2, A>) => Kind4<F, S1 | S2, R & R2, E | E2, A>
+  readonly flatten: <S1, S2, R, E, R2, E2, A>(
+    mma: Kind4<F, S1, R, E, Kind4<F, S2, R2, E2, A>>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, A>
+}
+
+export interface PipeableChain4EP<F extends MaURIS> extends PipeableApply4EP<F> {
+  readonly chain: <S1, R, E, A, B>(
+    f: (a: A) => Kind4<F, S1, R, E, B>
+  ) => <S2, R2, E2>(ma: Kind4<F, S2, R2, E2, A>) => Kind4<F, S1 | S2, R & R2, E | E2, B>
+  readonly chainFirst: <S1, R, E, A, B>(
+    f: (a: A) => Kind4<F, S1, R, E, B>
+  ) => <S2, R2, E2>(ma: Kind4<F, S2, R2, E2, A>) => Kind4<F, S1 | S2, R & R2, E | E2, A>
+  readonly flatten: <S1, S2, R, E, R2, E2, A>(
+    mma: Kind4<F, S1, R, E, Kind4<F, S2, R2, E2, A>>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, A>
+}
+
+export interface PipeableChain4EC<F extends MaURIS, E> extends PipeableApply4EC<F, E> {
+  readonly chain: <S1, R, A, B>(
+    f: (a: A) => Kind4<F, S1, R, E, B>
+  ) => <S2, R2>(ma: Kind4<F, S2, R2, E, A>) => Kind4<F, S1 | S2, R & R2, E, B>
+  readonly chainFirst: <S1, R, A, B>(
+    f: (a: A) => Kind4<F, S1, R, E, B>
+  ) => <S2, R2>(ma: Kind4<F, S2, R2, E, A>) => Kind4<F, S1 | S2, R & R2, E, A>
+  readonly flatten: <S1, S2, R, R2, A>(
+    mma: Kind4<F, S1, R, E, Kind4<F, S2, R2, E, A>>
+  ) => Kind4<F, S1 | S2, R & R2, E, A>
+}
+
+export interface PipeableApply4E<F extends MaURIS> extends PipeableFunctor4<F> {
+  readonly ap: <S1, R, E, A, E2>(
+    fa: Kind4<F, S1, R, E, A>
+  ) => <S2, R2, B>(
+    fab: Kind4<F, S2, R2, E2, (a: A) => B>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, B>
+  readonly apFirst: <S1, R, E, B>(
+    fb: Kind4<F, S1, R, E, B>
+  ) => <A, S2, R2, E2>(
+    fa: Kind4<F, S2, R2, E2, A>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, A>
+  readonly apSecond: <S1, R, E, B>(
+    fb: Kind4<F, S1, R, E, B>
+  ) => <A, S2, R2, E2>(
+    fa: Kind4<F, S2, R2, E2, A>
+  ) => Kind4<F, S1 | S2, R & R2, E | E2, B>
+}
+
+export interface PipeableApply4EP<F extends MaURIS> extends PipeableFunctor4<F> {
+  readonly ap: <S1, R, E, A, E2>(
+    fa: Kind4<F, S1, R, E, A>
+  ) => <S2, R2, B>(
+    fab: Kind4<F, S2, R2, E2, (a: A) => B>
+  ) => Kind4<F, unknown, R & R2, E | E2, B>
+  readonly apFirst: <S1, R, E, B>(
+    fb: Kind4<F, S1, R, E, B>
+  ) => <A, S2, R2, E2>(
+    fa: Kind4<F, S2, R2, E2, A>
+  ) => Kind4<F, unknown, R & R2, E | E2, A>
+  readonly apSecond: <S1, R, E, B>(
+    fb: Kind4<F, S1, R, E, B>
+  ) => <A, S2, R2, E2>(
+    fa: Kind4<F, S2, R2, E2, A>
+  ) => Kind4<F, unknown, R & R2, E | E2, B>
+}
+
+export interface PipeableApply4EC<F extends MaURIS, E>
+  extends PipeableFunctor4EC<F, E> {
+  readonly ap: <S1, R, A>(
+    fa: Kind4<F, S1, R, E, A>
+  ) => <S2, B, R2>(
+    fab: Kind4<F, S2, R2, E, (a: A) => B>
+  ) => Kind4<F, S1 | S2, R & R2, E, B>
+  readonly apFirst: <S1, R, B>(
+    fb: Kind4<F, S1, R, E, B>
+  ) => <A, S2, R2>(fa: Kind4<F, S2, R2, E, A>) => Kind4<F, S1 | S2, R & R2, E, A>
+  readonly apSecond: <S1, R, B>(
+    fb: Kind4<F, S1, R, E, B>
+  ) => <A, S2, R2>(fa: Kind4<F, S2, R2, E, A>) => Kind4<F, S1 | S2, R & R2, E, B>
+}
+
+export interface PipeableFunctor4EC<F extends MaURIS, E> {
+  readonly map: <A, B>(
+    f: (a: A) => B
+  ) => <S, R>(fa: Kind4<F, S, R, E, A>) => Kind4<F, S, R, E, B>
+}
+
+export interface PipeableMonadThrow4E<F extends MaURIS> {
+  readonly fromOption: <E>(
+    onNone: () => E
+  ) => <A>(ma: Option<A>) => Kind4<F, never, unknown, E, A>
+  readonly fromEither: <E, A>(ma: Either<E, A>) => Kind4<F, never, unknown, E, A>
+  readonly fromPredicate: {
+    <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): (
+      a: A
+    ) => Kind4<F, never, unknown, E, B>
+    <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): (
+      a: A
+    ) => Kind4<F, never, unknown, E, A>
+  }
+  readonly filterOrElse: {
+    <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <S, R>(
+      ma: Kind4<F, S, R, E, A>
+    ) => Kind4<F, S, R, E, B>
+    <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E): <S, R>(
+      ma: Kind4<F, S, R, E, A>
+    ) => Kind4<F, S, R, E, A>
+  }
+}
+
+export interface PipeableAlt4E<F extends MaURIS> {
+  readonly alt: <S1, R, E, A>(
+    that: () => Kind4<F, S1, R, E, A>
+  ) => <S2, R2, E2>(fa: Kind4<F, S1 | S2, R2, E2, A>) => Kind4<F, S1 | S2, R & R2, E, A>
+}
+
+declare module "fp-ts/lib/pipeable" {
+  export function pipeable<F extends MaURIS, I>(
+    I: {
+      URI: F
+    } & I
+  ): (I extends Chain4E<F>
+    ? PipeableChain4E<F>
+    : I extends Chain4EP<F>
+    ? PipeableChain4EP<F>
+    : I extends Apply4E<F>
+    ? PipeableApply4E<F>
+    : I extends Functor4<F>
+    ? PipeableFunctor4<F>
+    : {}) &
+    (I extends Contravariant4<F> ? PipeableContravariant4<F> : {}) &
+    (I extends FunctorWithIndex4<F, infer Ix> ? PipeableFunctorWithIndex4<F, Ix> : {}) &
+    (I extends Bifunctor4<F> ? PipeableBifunctor4<F> : {}) &
+    (I extends Extend4<F> ? PipeableExtend4<F> : {}) &
+    (I extends FoldableWithIndex4<F, infer Ix>
+      ? PipeableFoldableWithIndex4<F, Ix>
+      : I extends Foldable4<F>
+      ? PipeableFoldable4<F>
+      : {}) &
+    (I extends Alt4E<F> ? PipeableAlt4E<F> : {}) &
+    (I extends FilterableWithIndex4<F, infer Ix>
+      ? PipeableFilterableWithIndex4<F, Ix>
+      : I extends Filterable4<F>
+      ? PipeableFilterable4<F>
+      : I extends Compactable4<F>
+      ? PipeableCompactable4<F>
+      : {}) &
+    (I extends Profunctor4<F> ? PipeableProfunctor4<F> : {}) &
+    (I extends Semigroupoid4<F> ? PipeableSemigroupoid4<F> : {}) &
+    (I extends MonadThrow4E<F> ? PipeableMonadThrow4E<F> : {})
+  export function pipeable<F extends MaURIS, I, E>(
+    I: {
+      URI: F
+    } & I
+  ): (I extends Chain4EC<F, E>
+    ? PipeableChain4EC<F, E>
+    : I extends Apply4EC<F, E>
+    ? PipeableApply4EC<F, E>
+    : I extends Functor4EC<F, E>
+    ? PipeableFunctor4EC<F, E>
+    : {}) &
+    (I extends Alt4EC<F, E> ? PipeableAlt4EC<F, E> : {}) &
+    (I extends MonadThrow4EC<F, E> ? PipeableMonadThrow4<F> : {})
+}
+
+export interface MonadThrow4E<M extends MaURIS> extends Monad4E<M> {
+  readonly throwError: <E>(e: E) => Kind4<M, never, unknown, E, never>
+}
+
+export interface MonadThrow4EP<M extends MaURIS> extends Monad4EP<M> {
+  readonly throwError: <E>(e: E) => Kind4<M, never, unknown, E, never>
+}
+
+export interface MonadThrow4EC<M extends MaURIS, E> extends Monad4EC<M, E> {
+  readonly throwError: (e: E) => Kind4<M, never, unknown, E, never>
+}
+
+export interface MonadThrow4ECP<M extends MaURIS, E> extends Monad4ECP<M, E> {
+  readonly throwError: (e: E) => Kind4<M, never, unknown, E, never>
+}
+
+export interface Alt4EC<F extends MaURIS, E> extends Functor4EC<F, E> {
+  readonly alt: <S1, S2, R, R2, A>(
+    fx: Kind4<F, S1, R, E, A>,
+    fy: () => Kind4<F, S2, R2, E, A>
+  ) => Kind4<F, S1 | S2, R & R2, E, A>
+}
+
+export interface PipeableAlt4EC<F extends MaURIS, E> {
+  readonly alt: <S1, R, A>(
+    that: () => Kind4<F, S1, R, E, A>
+  ) => <S2, R2>(fa: Kind4<F, S2, R2, E, A>) => Kind4<F, S1 | S2, R & R2, E, A>
+}
+
+export interface PipeableMonadThrow4EC<F extends MaURIS, E> {
+  readonly fromOption: (
+    onNone: () => E
+  ) => <A>(ma: Option<A>) => Kind4<F, never, unknown, E, A>
+  readonly fromEither: <A>(ma: Either<E, A>) => Kind4<F, never, unknown, E, A>
+  readonly fromPredicate: {
+    <A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): (
+      a: A
+    ) => Kind4<F, never, unknown, E, B>
+    <A>(predicate: Predicate<A>, onFalse: (a: A) => E): (
+      a: A
+    ) => Kind4<F, never, unknown, E, A>
+  }
+  readonly filterOrElse: {
+    <A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): <S, R>(
+      ma: Kind4<F, S, R, E, A>
+    ) => Kind4<F, S, R, E, B>
+    <A>(predicate: Predicate<A>, onFalse: (a: A) => E): <S, R>(
+      ma: Kind4<F, S, R, E, A>
+    ) => Kind4<F, S, R, E, A>
+  }
+}
+
+declare module "fp-ts/lib/Traversable" {
+  export interface Traverse1<T extends URIS> {
+    <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <A, S, R, B>(
+      ta: Kind<T, A>,
+      f: (a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, unknown, R, E, Kind<T, B>>
+    <F extends MaURIS, E>(F: Applicative4EC<F, E>): <A, S, R, B>(
+      ta: Kind<T, A>,
+      f: (a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, S, R, E, Kind<T, B>>
+    <F extends MaURIS>(F: Applicative4EP<F>): <A, S, R, E, B>(
+      ta: Kind<T, A>,
+      f: (a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, unknown, R, E, Kind<T, B>>
+    <F extends MaURIS>(F: Applicative4E<F>): <A, S, R, E, B>(
+      ta: Kind<T, A>,
+      f: (a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, S, R, E, Kind<T, B>>
+  }
+  export interface Sequence1<T extends URIS> {
+    <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <S, R, A>(
+      ta: Kind<T, Kind4<F, S, R, E, A>>
+    ) => Kind4<F, unknown, R, E, Kind<T, A>>
+    <F extends MaURIS, E>(F: Applicative4EC<F, E>): <S, R, A>(
+      ta: Kind<T, Kind4<F, S, R, E, A>>
+    ) => Kind4<F, S, R, E, Kind<T, A>>
+    <F extends MaURIS>(F: Applicative4EP<F>): <S, R, E, A>(
+      ta: Kind<T, Kind4<F, S, R, E, A>>
+    ) => Kind4<F, unknown, R, E, Kind<T, A>>
+    <F extends MaURIS>(F: Applicative4E<F>): <S, R, E, A>(
+      ta: Kind<T, Kind4<F, S, R, E, A>>
+    ) => Kind4<F, S, R, E, Kind<T, A>>
+  }
+  export interface Traverse2<T extends URIS2> {
+    <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <TE, A, S, R, B>(
+      ta: Kind2<T, TE, A>,
+      f: (a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, unknown, R, E, Kind2<T, TE, B>>
+    <F extends MaURIS, E>(F: Applicative4EC<F, E>): <TE, A, S, R, B>(
+      ta: Kind2<T, TE, A>,
+      f: (a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, S, R, E, Kind2<T, TE, B>>
+    <F extends MaURIS>(F: Applicative4EP<F>): <TE, A, S, R, FE, B>(
+      ta: Kind2<T, TE, A>,
+      f: (a: A) => Kind4<F, S, R, FE, B>
+    ) => Kind4<F, unknown, R, FE, Kind2<T, TE, B>>
+    <F extends MaURIS>(F: Applicative4E<F>): <TE, A, S, R, FE, B>(
+      ta: Kind2<T, TE, A>,
+      f: (a: A) => Kind4<F, S, R, FE, B>
+    ) => Kind4<F, S, R, FE, Kind2<T, TE, B>>
+  }
+  export interface Sequence2<T extends URIS2> {
+    <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <TE, S, R, A>(
+      ta: Kind2<T, E, Kind4<F, S, R, E, A>>
+    ) => Kind4<F, unknown, R, E, Kind2<T, TE, A>>
+    <F extends MaURIS, E>(F: Applicative4EC<F, E>): <TE, S, R, A>(
+      ta: Kind2<T, E, Kind4<F, S, R, E, A>>
+    ) => Kind4<F, S, R, E, Kind2<T, TE, A>>
+    <F extends MaURIS>(F: Applicative4EP<F>): <TE, S, R, FE, A>(
+      ta: Kind2<T, TE, Kind4<F, S, R, FE, A>>
+    ) => Kind4<F, unknown, R, FE, Kind2<T, TE, A>>
+    <F extends MaURIS>(F: Applicative4E<F>): <TE, S, R, FE, A>(
+      ta: Kind2<T, TE, Kind4<F, S, R, FE, A>>
+    ) => Kind4<F, S, R, FE, Kind2<T, TE, A>>
+  }
+}
+
+declare module "fp-ts/lib/Witherable" {
+  export interface Wilt1<W extends URIS> {
+    <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <A, S, R, B, C>(
+      wa: Kind<W, A>,
+      f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+    ) => Kind4<F, unknown, R, E, Separated<Kind<W, B>, Kind<W, C>>>
+    <F extends MaURIS, E>(F: Applicative4EC<F, E>): <A, S, R, B, C>(
+      wa: Kind<W, A>,
+      f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+    ) => Kind4<F, S, R, E, Separated<Kind<W, B>, Kind<W, C>>>
+    <F extends MaURIS>(F: Applicative4EP<F>): <A, S, R, E, B, C>(
+      wa: Kind<W, A>,
+      f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+    ) => Kind4<F, unknown, R, E, Separated<Kind<W, B>, Kind<W, C>>>
+    <F extends MaURIS>(F: Applicative4E<F>): <A, S, R, E, B, C>(
+      wa: Kind<W, A>,
+      f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+    ) => Kind4<F, S, R, E, Separated<Kind<W, B>, Kind<W, C>>>
+  }
+  export interface Wither1<W extends URIS> {
+    <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <A, S, R, B>(
+      ta: Kind<W, A>,
+      f: (a: A) => Kind4<F, S, R, E, Option<B>>
+    ) => Kind4<F, unknown, R, E, Kind<W, B>>
+    <F extends MaURIS, E>(F: Applicative4EC<F, E>): <A, S, R, B>(
+      ta: Kind<W, A>,
+      f: (a: A) => Kind4<F, S, R, E, Option<B>>
+    ) => Kind4<F, S, R, E, Kind<W, B>>
+    <F extends MaURIS>(F: Applicative4EP<F>): <A, S, R, E, B>(
+      ta: Kind<W, A>,
+      f: (a: A) => Kind4<F, unknown, R, E, Option<B>>
+    ) => Kind4<F, unknown, R, E, Kind<W, B>>
+    <F extends MaURIS>(F: Applicative4E<F>): <A, S, R, E, B>(
+      ta: Kind<W, A>,
+      f: (a: A) => Kind4<F, S, R, E, Option<B>>
+    ) => Kind4<F, S, R, E, Kind<W, B>>
+  }
+}
+
+declare module "fp-ts/lib/TraversableWithIndex" {
+  export interface TraverseWithIndex1<T extends URIS, I> {
+    <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <A, S, R, B>(
+      ta: Kind<T, A>,
+      f: (i: I, a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, unknown, R, E, Kind<T, B>>
+    <F extends MaURIS, E>(F: Applicative4EC<F, E>): <A, S, R, B>(
+      ta: Kind<T, A>,
+      f: (i: I, a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, S, R, E, Kind<T, B>>
+    <F extends MaURIS>(F: Applicative4EP<F>): <A, S, R, E, B>(
+      ta: Kind<T, A>,
+      f: (i: I, a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, unknown, R, E, Kind<T, B>>
+    <F extends MaURIS>(F: Applicative4E<F>): <A, S, R, E, B>(
+      ta: Kind<T, A>,
+      f: (i: I, a: A) => Kind4<F, S, R, E, B>
+    ) => Kind4<F, S, R, E, Kind<T, B>>
+  }
+}

--- a/packages/core/src/Base/index.ts
+++ b/packages/core/src/Base/index.ts
@@ -152,7 +152,8 @@ export type {
   CPartition3C,
   CPartition4,
   Filter2,
-  Partition2
+  Partition2,
+  Filter1
 } from "./Filterable"
 
 export {
@@ -312,3 +313,75 @@ export type {
 } from "./TraversableWithIndex"
 
 export type { COf, COf1, COf2, COf2C, COf3, COf3C, COf4, COf4C } from "./Of"
+
+export type {
+  Alt4E,
+  Alt4EC,
+  Applicative4E,
+  Applicative4EC,
+  Applicative4ECP,
+  Applicative4EP,
+  Apply4E,
+  Apply4EC,
+  Apply4ECP,
+  Apply4EP,
+  Chain4E,
+  Chain4EC,
+  Chain4ECP,
+  Chain4EP,
+  Do4CE,
+  Do4CE_,
+  Functor4EC,
+  Monad4E,
+  Monad4EC,
+  Monad4ECP,
+  Monad4EP,
+  MonadThrow4E,
+  MonadThrow4EC,
+  MonadThrow4ECP,
+  MonadThrow4EP,
+  PipeableAlt4E,
+  PipeableAlt4EC,
+  PipeableApply4E,
+  PipeableApply4EC,
+  PipeableApply4EP,
+  PipeableChain4E,
+  PipeableChain4EC,
+  PipeableChain4EP,
+  PipeableFunctor4EC,
+  PipeableMonadThrow4E,
+  PipeableMonadThrow4EC
+} from "./Overloads"
+
+export type { Functor2, Functor1 } from "fp-ts/lib/Functor"
+export type { FunctorWithIndex1 } from "fp-ts/lib/FunctorWithIndex"
+export type { Contravariant2, Contravariant1 } from "fp-ts/lib/Contravariant"
+export type { Compactable1 } from "fp-ts/lib/Compactable"
+export type { Filterable1, Filterable2 } from "fp-ts/lib/Filterable"
+export type { Witherable1, Witherable2C } from "fp-ts/lib/Witherable"
+export type { Apply2C } from "fp-ts/lib/Apply"
+export type { Chain2C } from "fp-ts/lib/Chain"
+export type { Bifunctor2 } from "fp-ts/lib/Bifunctor"
+export type { Monad2, Monad1, Monad2C } from "fp-ts/lib/Monad"
+export type { Comonad1, Comonad2 } from "fp-ts/lib/Comonad"
+export type { Foldable2, Foldable1 } from "fp-ts/lib/Foldable"
+export type { Unfoldable1 } from "fp-ts/lib/Unfoldable"
+export type { FoldableWithIndex1 } from "fp-ts/lib/FoldableWithIndex"
+export type { Traversable1, Traversable2 } from "fp-ts/lib/Traversable"
+export type { TraversableWithIndex1 } from "fp-ts/lib/TraversableWithIndex"
+export type { FilterableWithIndex1 } from "fp-ts/lib/FilterableWithIndex"
+export type { Alt2, Alt1, Alt2C } from "fp-ts/lib/Alt"
+export type { Alternative1 } from "fp-ts/lib/Alternative"
+export type { Extend2, Extend1 } from "fp-ts/lib/Extend"
+export type { ChainRec2, ChainRec1, ChainRec2C } from "fp-ts/lib/ChainRec"
+export type { MonadThrow2 } from "fp-ts/lib/MonadThrow"
+export type {
+  Applicative2,
+  Applicative1,
+  Applicative,
+  Applicative3,
+  Applicative2C,
+  Applicative3C,
+  Applicative4
+} from "fp-ts/lib/Applicative"
+export type { Semigroupoid2 } from "fp-ts/lib/Semigroupoid"

--- a/packages/core/src/Base/index.ts
+++ b/packages/core/src/Base/index.ts
@@ -385,3 +385,12 @@ export type {
   Applicative4
 } from "fp-ts/lib/Applicative"
 export type { Semigroupoid2 } from "fp-ts/lib/Semigroupoid"
+
+import type * as H from "./HKT"
+
+declare module "fp-ts/lib/HKT" {
+  interface URItoKind<A> extends H.URItoKind<A> {}
+  interface URItoKind2<E, A> extends H.URItoKind2<E, A> {}
+  interface URItoKind3<R, E, A> extends H.URItoKind3<R, E, A> {}
+  interface URItoKind4<S, R, E, A> extends H.URItoKind4<S, R, E, A> {}
+}

--- a/packages/core/src/Const/index.ts
+++ b/packages/core/src/Const/index.ts
@@ -13,7 +13,10 @@ import type {
   CApply2C,
   CBifunctor2,
   CContravariant2,
-  CFunctor2
+  CFunctor2,
+  Functor2,
+  Contravariant2,
+  Bifunctor2
 } from "../Base"
 import type { Eq } from "../Eq"
 import { identity, unsafeCoerce } from "../Function"
@@ -21,8 +24,6 @@ import type { Monoid } from "../Monoid"
 import type { Bounded, Ord } from "../Ord"
 import type { Semigroup } from "../Semigroup"
 import type { Show } from "../Show"
-
-export { const_ as const }
 
 export type Const<E, A> = E & {
   readonly _A: A
@@ -112,10 +113,26 @@ declare module "../Base/HKT" {
   }
 }
 
-export const const_: CFunctor2<URI> & CContravariant2<URI> & CBifunctor2<URI> = {
+const const_: CFunctor2<URI> & CContravariant2<URI> & CBifunctor2<URI> = {
   URI,
   map,
   contramap,
   bimap,
   mapLeft
 }
+
+export { const_ as const }
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+const const__: Functor2<URI> & Contravariant2<URI> & Bifunctor2<URI> = {
+  URI,
+  map: map_,
+  contramap: contramap_,
+  bimap: bimap_,
+  mapLeft: mapLeft_
+}
+
+export { const__ as const_ }

--- a/packages/core/src/Do/index.ts
+++ b/packages/core/src/Do/index.ts
@@ -35,6 +35,7 @@ import type {
 } from "../Base/Monad"
 import type { URI as EitherURI } from "../Either/index"
 import type { Monad2M, Applicative2M } from "../Either/overloads"
+export { Do as Do_ } from "fp-ts-contrib/lib/Do"
 
 class DoClass<M> {
   constructor(readonly M: CMonad<M> & CApplicative<M>, private result: HKT<M, any>) {}

--- a/packages/core/src/EffectOption/index.ts
+++ b/packages/core/src/EffectOption/index.ts
@@ -2,7 +2,13 @@
 
 import * as AP from "../Apply"
 import * as A from "../Array"
-import type { CMonad4MA, CApplicative4MA, CApplicative4MAP } from "../Base"
+import type {
+  CMonad4MA,
+  CApplicative4MA,
+  CApplicative4MAP,
+  Monad4E,
+  Monad4EP
+} from "../Base"
 import type {
   STypeOf,
   UnionToIntersection,
@@ -459,3 +465,24 @@ export const parWiltRecord =
 export const parWiltRecord_ =
   /*#__PURE__*/
   (() => RE.wilt_(par(effectOption)))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const effectOption_: Monad4E<URI> = {
+  URI,
+  ap: ap_,
+  chain: chain_,
+  map: map_,
+  of
+}
+
+export const effectOptionPar_: Monad4EP<URI> = {
+  URI,
+  _CTX: "async",
+  ap: parAp_,
+  chain: chain_,
+  map: map_,
+  of
+}

--- a/packages/core/src/Either/overloads.ts
+++ b/packages/core/src/Either/overloads.ts
@@ -32,37 +32,6 @@ export interface Apply2M<F extends URI> extends CFunctor2<F> {
   ) => <E>(fab: Kind2<F, E, (a: A) => B>) => Kind2<F, E | E2, B>
 }
 
-declare module "../Base/Apply" {
-  export function sequenceT<F extends URI>(
-    F: Apply2M<F>
-  ): <Z extends Array<Kind2<F, any, any>>>(
-    ...t: Z & {
-      readonly 0: Kind2<F, any, any>
-    }
-  ) => Kind2<
-    F,
-    {
-      [K in keyof Z]: Z[K] extends Kind2<F, infer _E, infer _A> ? _E : never
-    }[number],
-    {
-      [K in keyof Z]: Z[K] extends Kind2<F, infer _E, infer _A> ? _A : never
-    }[number]
-  >
-
-  export function sequenceS<F extends URI>(
-    F: Apply2M<F>
-  ): <NER extends Record<string, Kind2<F, any, any>>>(
-    r: EnforceNonEmptyRecord<NER> & Record<string, Kind2<F, any, any>>
-  ) => Kind2<
-    F,
-    {
-      [K in keyof NER]: [NER[K]] extends [Kind2<F, infer _E, infer _A>] ? _E : never
-    }[keyof NER],
-    {
-      [K in keyof NER]: [NER[K]] extends [Kind2<F, infer _E, infer _A>] ? _A : never
-    }
-  >
-}
 export interface Applicative2M<F extends URI> extends Apply2M<F>, COf2<F> {}
 export interface Monad2M<M extends URI> extends Chain2M<M>, COf2<M> {}
 export interface CAlt2M<F extends URI> extends CFunctor2<F> {

--- a/packages/core/src/Eq/index.ts
+++ b/packages/core/src/Eq/index.ts
@@ -9,7 +9,7 @@
  * 2. Symmetry: `E.equals(a, b) === E.equals(b, a)`
  * 3. Transitivity: if `E.equals(a, b) === true` and `E.equals(b, c) === true`, then `E.equals(a, c) === true`
  */
-import type { CContravariant1 } from "../Base"
+import type { CContravariant1, Contravariant1 } from "../Base"
 import type { Monoid } from "../Monoid"
 import type { ReadonlyRecord } from "../Readonly/Record"
 
@@ -110,3 +110,12 @@ export const eqDate: Eq<Date> =
   (() => contramap_(eqNumber, (date: Date) => date.valueOf()))()
 
 export const eqString: Eq<string> = eqStrict
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const eq_: Contravariant1<URI> = {
+  URI,
+  contramap: contramap_
+}

--- a/packages/core/src/Identity/index.ts
+++ b/packages/core/src/Identity/index.ts
@@ -11,7 +11,16 @@ import type {
   CTraversable1,
   CAlt1,
   CComonad1,
-  CApplicative1
+  CApplicative1,
+  Monad1,
+  Foldable1,
+  Traversable1,
+  Alt1,
+  Comonad1,
+  ChainRec1,
+  Applicative1,
+  Traverse1,
+  Applicative
 } from "../Base"
 import { tailRec, CChainRec1 } from "../Base/ChainRec"
 import { Do as DoG } from "../Do"
@@ -104,6 +113,13 @@ export const traverse: CTraverse1<URI> = <F>(F: CApplicative<F>) => <A, B>(
   return (ta) => F.map(id)(f(ta))
 }
 
+export const traverse_: Traverse1<URI> = <F>(F: CApplicative<F>) => <A, B>(
+  ta: Identity<A>,
+  f: (a: A) => HKT<F, B>
+): HKT<F, Identity<B>> => {
+  return F.map(id)(f(ta))
+}
+
 export const URI = "@matechs/core/Identity"
 
 export type URI = typeof URI
@@ -161,3 +177,43 @@ export const sequenceS =
 export const sequenceT =
   /*#__PURE__*/
   (() => AP.sequenceT(identityAp))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+const traverse__ = <F>(F: Applicative<F>) => <A, B>(
+  ta: Identity<A>,
+  f: (a: A) => HKT<F, B>
+): HKT<F, Identity<B>> => {
+  return F.map(f(ta), id)
+}
+
+const sequence_ = <F>(F: Applicative<F>) => <A>(
+  ta: Identity<HKT<F, A>>
+): HKT<F, Identity<A>> => {
+  return F.map(ta, id)
+}
+
+export const identity_: Monad1<URI> &
+  Foldable1<URI> &
+  Traversable1<URI> &
+  Alt1<URI> &
+  Comonad1<URI> &
+  ChainRec1<URI> &
+  Applicative1<URI> = {
+  URI,
+  map: map_,
+  of: id,
+  ap: ap_,
+  chain: chain_,
+  reduce: reduce_,
+  foldMap: foldMap_,
+  reduceRight: reduceRight_,
+  traverse: traverse__,
+  sequence: sequence_,
+  alt: alt_,
+  extract,
+  extend: extend_,
+  chainRec
+}

--- a/packages/core/src/List/index.ts
+++ b/packages/core/src/List/index.ts
@@ -1,7 +1,7 @@
 /* adapted from https://github.com/rzeigler/waveguide */
 
 import * as AP from "../Apply"
-import type { CApplicative1, CMonad1 } from "../Base"
+import type { CApplicative1, CMonad1, Monad1 } from "../Base"
 import { Do as DoG } from "../Do"
 import { flip } from "../Function"
 import type { FunctionN, Lazy, Predicate } from "../Function"
@@ -251,3 +251,15 @@ export const sequenceS =
 export const sequenceT =
   /*#__PURE__*/
   (() => AP.sequenceT(listAp))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const list_: Monad1<URI> = {
+  URI,
+  ap: ap_,
+  chain: chain_,
+  map: map_,
+  of
+}

--- a/packages/core/src/Managed/index.ts
+++ b/packages/core/src/Managed/index.ts
@@ -2,7 +2,13 @@
 
 import * as AP from "../Apply"
 import * as A from "../Array"
-import { CMonad4MA, CApplicative4MAP, CApplicative4MA } from "../Base"
+import {
+  CMonad4MA,
+  CApplicative4MAP,
+  CApplicative4MA,
+  Monad4E,
+  Monad4EP
+} from "../Base"
 import { STypeOf, RTypeOf, ETypeOf, ATypeOf } from "../Base/Apply"
 import * as D from "../Do"
 import * as T from "../Effect"
@@ -865,3 +871,24 @@ export const parWiltRecord =
 export const parWiltRecord_ =
   /*#__PURE__*/
   (() => RE.wilt_(par(managed)))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const managed_: Monad4E<URI> = {
+  URI,
+  ap: ap_,
+  chain: chain_,
+  map: map_,
+  of: pure
+}
+
+export const managedPar_: Monad4EP<URI> = {
+  URI,
+  _CTX: "async",
+  ap: parAp_,
+  chain: chain_,
+  map: map_,
+  of: pure
+}

--- a/packages/core/src/Map/index.ts
+++ b/packages/core/src/Map/index.ts
@@ -32,7 +32,8 @@ import type {
   URIS2,
   URIS3,
   Wither2C,
-  Wilt2C
+  Wilt2C,
+  Filterable2
 } from "../Base"
 import { Either } from "../Either"
 import type { Eq } from "../Eq"
@@ -443,4 +444,19 @@ export const mapFilterable: CFilterable2<URI> = {
   filterMap,
   partition,
   partitionMap
+}
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const mapFilterable_: Filterable2<URI> = {
+  URI,
+  map: map_,
+  compact,
+  separate,
+  filter: filter_,
+  filterMap: filterMap_,
+  partition: partition_,
+  partitionMap: partitionMap_
 }

--- a/packages/core/src/NonEmptyArray/index.ts
+++ b/packages/core/src/NonEmptyArray/index.ts
@@ -18,7 +18,14 @@ import type {
   CTraverse1,
   CTraverseWithIndex1,
   Traverse1,
-  TraverseWithIndex1
+  TraverseWithIndex1,
+  Monad1,
+  Comonad1,
+  TraversableWithIndex1,
+  FunctorWithIndex1,
+  FoldableWithIndex1,
+  Alt1,
+  Applicative1
 } from "../Base"
 import { Do as DoG } from "../Do"
 import type { Eq } from "../Eq"
@@ -525,31 +532,11 @@ export const nonEmptyArray: CMonad1<URI> &
   alt
 }
 
-export const nonEmptyArrayAp: CMonad1<URI> &
-  CComonad1<URI> &
-  CTraversableWithIndex1<URI, number> &
-  CFunctorWithIndex1<URI, number> &
-  CFoldableWithIndex1<URI, number> &
-  CAlt1<URI> &
-  CApplicative1<URI> = {
+export const nonEmptyArrayAp: CApplicative1<URI> = {
   URI,
   map,
-  mapWithIndex,
   of,
-  ap,
-  chain,
-  extend,
-  extract: head,
-  reduce,
-  foldMap,
-  reduceRight,
-  traverse,
-  sequence,
-  reduceWithIndex,
-  foldMapWithIndex,
-  reduceRightWithIndex,
-  traverseWithIndex,
-  alt
+  ap
 }
 
 export const nonEmptyArrayMonad: CMonad1<URI> & CApplicative1<URI> = {
@@ -569,3 +556,37 @@ export const sequenceS =
 export const sequenceT =
   /*#__PURE__*/
   (() => AP.sequenceT(nonEmptyArrayAp))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const nonEmptyArray_: Monad1<URI> &
+  Comonad1<URI> &
+  TraversableWithIndex1<URI, number> &
+  FunctorWithIndex1<URI, number> &
+  FoldableWithIndex1<URI, number> &
+  Alt1<URI> &
+  Applicative1<URI> =
+  /*#__PURE__*/
+  (() =>
+    ({
+      URI,
+      map: map_,
+      mapWithIndex: mapWithIndex_,
+      of,
+      ap: ap_,
+      chain: chain_,
+      extend: extend_,
+      extract: head,
+      reduce: reduce_,
+      foldMap: foldMap_,
+      reduceRight: reduceRight_,
+      traverse: RNEA.readonlyNonEmptyArray_.traverse as any,
+      sequence: RNEA.readonlyNonEmptyArray_.sequence as any,
+      reduceWithIndex: reduceWithIndex_,
+      foldMapWithIndex: foldMapWithIndex_,
+      reduceRightWithIndex: reduceRightWithIndex_,
+      traverseWithIndex: RNEA.readonlyNonEmptyArray_.traverseWithIndex as any,
+      alt: alt_
+    } as const))()

--- a/packages/core/src/Ord/index.ts
+++ b/packages/core/src/Ord/index.ts
@@ -1,6 +1,6 @@
 /* adapted from https://github.com/gcanti/fp-ts */
 
-import type { CContravariant1 } from "../Base"
+import type { CContravariant1, Contravariant1 } from "../Base"
 import { strictEqual } from "../Eq"
 import type { Eq } from "../Eq"
 import type { Monoid } from "../Monoid"
@@ -281,4 +281,13 @@ export function getSemigroup<A = never>(): Semigroup<Ord<A>> {
     concat: (x, y) =>
       fromCompare((a, b) => monoidOrdering.concat(x.compare(a, b), y.compare(a, b)))
   }
+}
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const ord_: Contravariant1<URI> = {
+  URI,
+  contramap: contramap_
 }

--- a/packages/core/src/Readonly/Map/index.ts
+++ b/packages/core/src/Readonly/Map/index.ts
@@ -33,7 +33,8 @@ import type {
   Partition2,
   Traverse2C,
   Wither2C,
-  Wilt2C
+  Wilt2C,
+  Filterable2
 } from "../../Base"
 import { isLeft, Either } from "../../Either"
 import { fromEquals } from "../../Eq"
@@ -1132,4 +1133,19 @@ export const readonlyMapFilterable: CFilterable2<URI> = {
   filterMap,
   partition,
   partitionMap
+}
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const readonlyMapFilterable_: Filterable2<URI> = {
+  URI,
+  map: map_,
+  compact,
+  separate,
+  filter: filter_,
+  filterMap: filterMap_,
+  partition: partition_,
+  partitionMap: partitionMap_
 }

--- a/packages/core/src/Readonly/NonEmptyArray/index.ts
+++ b/packages/core/src/Readonly/NonEmptyArray/index.ts
@@ -18,7 +18,14 @@ import type {
   CTraverse1,
   CTraverseWithIndex1,
   Traverse1,
-  TraverseWithIndex1
+  TraverseWithIndex1,
+  Monad1,
+  Comonad1,
+  TraversableWithIndex1,
+  FunctorWithIndex1,
+  FoldableWithIndex1,
+  Alt1,
+  Applicative1
 } from "../../Base"
 import { Do as DoG } from "../../Do"
 import type { Eq } from "../../Eq"
@@ -698,3 +705,37 @@ export const sequenceS =
 export const sequenceT =
   /*#__PURE__*/
   (() => AP.sequenceT(readonlyNonEmptyAp))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const readonlyNonEmptyArray_: Monad1<URI> &
+  Comonad1<URI> &
+  TraversableWithIndex1<URI, number> &
+  FunctorWithIndex1<URI, number> &
+  FoldableWithIndex1<URI, number> &
+  Alt1<URI> &
+  Applicative1<URI> =
+  /*#__PURE__*/
+  (() =>
+    ({
+      URI,
+      map: map_,
+      mapWithIndex: mapWithIndex_,
+      of,
+      ap: ap_,
+      chain: chain_,
+      extend: extend_,
+      extract: head,
+      reduce: reduce_,
+      foldMap: foldMap_,
+      reduceRight: reduceRight_,
+      traverse: RA.readonlyArray_.traverse as any,
+      sequence: RA.readonlyArray_.sequence as any,
+      reduceWithIndex: reduceWithIndex_,
+      foldMapWithIndex: foldMapWithIndex_,
+      reduceRightWithIndex: reduceRightWithIndex_,
+      traverseWithIndex: RA.readonlyArray_.traverseWithIndex as any,
+      alt: alt_
+    } as const))()

--- a/packages/core/src/Readonly/Record/index.ts
+++ b/packages/core/src/Readonly/Record/index.ts
@@ -36,7 +36,25 @@ import type {
   URIS,
   URIS2,
   URIS3,
-  URIS4
+  URIS4,
+  FunctorWithIndex1,
+  Foldable1,
+  TraversableWithIndex1,
+  Compactable1,
+  FilterableWithIndex1,
+  Witherable1,
+  FoldableWithIndex1,
+  Applicative4EP,
+  Applicative4E,
+  Applicative4ECP,
+  Applicative4EC,
+  Applicative4,
+  Applicative3,
+  Applicative3C,
+  Applicative2,
+  Applicative2C,
+  Applicative1,
+  Applicative
 } from "../../Base"
 import type { Either } from "../../Either"
 import { Eq, fromEquals } from "../../Eq"
@@ -1875,4 +1893,385 @@ export const readonlyRecord: CFunctorWithIndex1<URI, string> &
   partitionWithIndex,
   filterMapWithIndex,
   filterWithIndex
+}
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export function traverseWithIndex__<F extends URIS4>(
+  F: Applicative4EP<F>
+): <K extends string, S, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS4, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, S, R, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS4, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, S, R, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS3, E>(
+  F: Applicative3C<F, E>
+): <K extends string, R, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind2<F, E, B>
+) => Kind2<F, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS2, E>(
+  F: Applicative2C<F, E>
+): <K extends string, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind2<F, E, B>
+) => Kind2<F, E, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => Kind<F, B>
+) => Kind<F, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F>(
+  F: Applicative<F>
+): <K extends string, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (k: K, a: A) => HKT<F, B>
+) => HKT<F, ReadonlyRecord<K, B>>
+export function traverseWithIndex__<F>(
+  F: Applicative<F>
+): <A, B>(
+  ta: ReadonlyRecord<string, A>,
+  f: (k: string, a: A) => HKT<F, B>
+) => HKT<F, ReadonlyRecord<string, B>> {
+  return <A, B>(
+    ta: ReadonlyRecord<string, A>,
+    f: (k: string, a: A) => HKT<F, B>
+  ): HKT<F, ReadonlyRecord<string, B>> => {
+    const keys = Object.keys(ta)
+    if (keys.length === 0) {
+      return F.of(empty)
+    }
+    let fr: HKT<F, Record<string, B>> = F.of({})
+    for (const key of keys) {
+      fr = F.ap(
+        F.map(fr, (r) => (b: B) => {
+          r[key] = b
+          return r
+        }),
+        f(key, ta[key])
+      )
+    }
+    return fr
+  }
+}
+
+export function traverse__<F extends MaURIS, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, S, R, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends MaURIS, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, S, R, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends MaURIS>(
+  F: Applicative4EP<F>
+): <K extends string, S, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends MaURIS>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, R, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends URIS3, E>(
+  F: Applicative3C<F, E>
+): <K extends string, R, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, E, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind2<F, E, B>
+) => Kind2<F, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends URIS2, E>(
+  F: Applicative2C<F, E>
+): <K extends string, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind2<F, E, B>
+) => Kind2<F, E, ReadonlyRecord<K, B>>
+export function traverse__<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind<F, B>
+) => Kind<F, ReadonlyRecord<K, B>>
+export function traverse__<F>(
+  F: Applicative<F>
+): <K extends string, A, B>(
+  ta: ReadonlyRecord<K, A>,
+  f: (a: A) => HKT<F, B>
+) => HKT<F, ReadonlyRecord<K, B>>
+export function traverse__<F>(
+  F: Applicative<F>
+): <A, B>(
+  ta: ReadonlyRecord<string, A>,
+  f: (a: A) => HKT<F, B>
+) => HKT<F, ReadonlyRecord<string, B>> {
+  const traverseWithIndexF = traverseWithIndex__(F)
+  return (fa, f) => traverseWithIndexF(fa, (_, a) => f(a))
+}
+
+export const wilt__: {
+  <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <K extends string, A, S, R, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, unknown, R, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends MaURIS>(F: Applicative4EP<F>): <K extends string, A, S, R, E, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, unknown, R, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends MaURIS, E>(F: Applicative4EC<F, E>): <K extends string, A, S, R, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, S, R, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends MaURIS>(F: Applicative4E<F>): <K extends string, A, S, R, E, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, S, R, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends URIS4>(F: Applicative4<F>): <K extends string, A, S, R, E, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, S, R, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends URIS3>(F: Applicative3<F>): <K extends string, A, R, E, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind3<F, R, E, Either<B, C>>
+  ) => Kind3<F, R, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends URIS3, E>(F: Applicative3C<F, E>): <K extends string, A, R, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind3<F, R, E, Either<B, C>>
+  ) => Kind3<F, R, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends URIS2>(F: Applicative2<F>): <K extends string, A, E, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind2<F, E, Either<B, C>>
+  ) => Kind2<F, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends URIS2, E>(F: Applicative2C<F, E>): <K extends string, A, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind2<F, E, Either<B, C>>
+  ) => Kind2<F, E, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F extends URIS>(F: Applicative1<F>): <K extends string, A, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => Kind<F, Either<B, C>>
+  ) => Kind<F, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+  <F>(F: Applicative<F>): <K extends string, A, B, C>(
+    wa: ReadonlyRecord<K, A>,
+    f: (a: A) => HKT<F, Either<B, C>>
+  ) => HKT<F, Separated<ReadonlyRecord<K, B>, ReadonlyRecord<K, C>>>
+} = <F>(
+  F: Applicative<F>
+): (<A, B, C>(
+  wa: ReadonlyRecord<string, A>,
+  f: (a: A) => HKT<F, Either<B, C>>
+) => HKT<F, Separated<ReadonlyRecord<string, B>, ReadonlyRecord<string, C>>>) => {
+  const traverseF = traverse__(F)
+  return (wa, f) => F.map(traverseF(wa, f), separate)
+}
+
+export function sequence_<F extends URIS4, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, S, R, A>(
+  ta: ReadonlyRecord<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS4, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, S, R, A>(
+  ta: ReadonlyRecord<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A>(
+  ta: ReadonlyRecord<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS4>(
+  F: Applicative4EP<F>
+): <K extends string, S, R, E, A>(
+  ta: ReadonlyRecord<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A>(
+  ta: ReadonlyRecord<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, R, E, A>(
+  ta: ReadonlyRecord<K, Kind3<F, R, E, A>>
+) => Kind3<F, R, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS3, E>(
+  F: Applicative3C<F, E>
+): <K extends string, R, A>(
+  ta: ReadonlyRecord<K, Kind3<F, R, E, A>>
+) => Kind3<F, R, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, E, A>(
+  ta: ReadonlyRecord<K, Kind2<F, E, A>>
+) => Kind2<F, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS2, E>(
+  F: Applicative2C<F, E>
+): <K extends string, A>(
+  ta: ReadonlyRecord<K, Kind2<F, E, A>>
+) => Kind2<F, E, ReadonlyRecord<K, A>>
+export function sequence_<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A>(
+  ta: ReadonlyRecord<K, Kind<F, A>>
+) => Kind<F, ReadonlyRecord<K, A>>
+export function sequence_<F>(
+  F: Applicative<F>
+): <K extends string, A>(
+  ta: ReadonlyRecord<K, HKT<F, A>>
+) => HKT<F, ReadonlyRecord<K, A>>
+export function sequence_<F>(
+  F: Applicative<F>
+): <A>(ta: ReadonlyRecord<string, HKT<F, A>>) => HKT<F, ReadonlyRecord<string, A>> {
+  return (ta) => traverseWithIndex__(F)(ta, (_, a) => a)
+}
+
+export function wither__<F extends URIS4>(
+  F: Applicative4EP<F>
+): <K extends string, A, S, R, E, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, B>>
+export function wither__<F extends URIS4, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, A, S, R, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, unknown, R, E, ReadonlyRecord<K, B>>
+export function wither__<F extends URIS4, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, A, S, R, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function wither__<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, A, S, R, E, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function wither__<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, A, S, R, E, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, S, R, E, ReadonlyRecord<K, B>>
+export function wither__<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, A, R, E, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind3<F, R, E, Option<B>>
+) => Kind3<F, R, E, ReadonlyRecord<K, B>>
+export function wither__<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, A, E, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind2<F, E, Option<B>>
+) => Kind2<F, E, ReadonlyRecord<K, B>>
+export function wither__<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => Kind<F, Option<B>>
+) => Kind<F, ReadonlyRecord<K, B>>
+export function wither__<F>(
+  F: Applicative<F>
+): <K extends string, A, B>(
+  wa: ReadonlyRecord<K, A>,
+  f: (a: A) => HKT<F, Option<B>>
+) => HKT<F, ReadonlyRecord<K, B>> {
+  const traverseF = traverse__(F)
+  return (wa, f) => F.map(traverseF(wa, f), compact)
+}
+
+export const readonlyRecord_: FunctorWithIndex1<URI, string> &
+  Foldable1<URI> &
+  TraversableWithIndex1<URI, string> &
+  Compactable1<URI> &
+  FilterableWithIndex1<URI, string> &
+  Witherable1<URI> &
+  FoldableWithIndex1<URI, string> = {
+  URI,
+  map: map_,
+  reduce: reduce_,
+  foldMap: foldMap_,
+  reduceRight: reduceRight_,
+  traverse: traverse__,
+  sequence: sequence_,
+  compact,
+  separate,
+  filter: filter_,
+  filterMap: filterMap_,
+  partition: partition_,
+  partitionMap: partitionMap_,
+  wither: wither__,
+  wilt: wilt__,
+  mapWithIndex: mapWithIndex_,
+  reduceWithIndex: reduceWithIndex_,
+  foldMapWithIndex: foldMapWithIndex_,
+  reduceRightWithIndex: reduceRightWithIndex_,
+  traverseWithIndex: traverseWithIndex__,
+  partitionMapWithIndex: partitionMapWithIndex_,
+  partitionWithIndex: partitionWithIndex_,
+  filterMapWithIndex: filterMapWithIndex_,
+  filterWithIndex: filterWithIndex_
 }

--- a/packages/core/src/Readonly/Tuple/index.ts
+++ b/packages/core/src/Readonly/Tuple/index.ts
@@ -15,7 +15,18 @@ import type {
   CComonad2,
   CFoldable2,
   CTraversable2,
-  Traverse2
+  Traverse2,
+  Semigroupoid2,
+  Bifunctor2,
+  Foldable2,
+  Comonad2,
+  Traversable2,
+  Applicative,
+  Apply2C,
+  Applicative2C,
+  Chain2C,
+  Monad2C,
+  ChainRec2C
 } from "../../Base"
 import type { Either } from "../../Either"
 import type { Monoid } from "../../Monoid"
@@ -270,4 +281,73 @@ export const readonlyTuple: CSemigroupoid2<URI> &
   reduceRight,
   traverse,
   sequence
+}
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const readonlyTuple_: Semigroupoid2<URI> &
+  Bifunctor2<URI> &
+  Comonad2<URI> &
+  Foldable2<URI> &
+  Traversable2<URI> = {
+  URI,
+  compose: compose_,
+  map: map_,
+  bimap: bimap_,
+  mapLeft: mapLeft_,
+  extract: fst,
+  extend: extend_,
+  reduce: reduce_,
+  foldMap: foldMap_,
+  reduceRight: reduceRight_,
+  traverse: <F>(F: Applicative<F>) => <S, A, B>(
+    as: readonly [A, S],
+    f: (a: A) => HKT<F, B>
+  ): HKT<F, readonly [B, S]> => {
+    return F.map(pipe(as, fst, f), (b) => [b, snd(as)])
+  },
+  sequence: <F>(F: Applicative<F>) => <A, S>(
+    fas: readonly [HKT<F, A>, S]
+  ): HKT<F, readonly [A, S]> => {
+    return F.map(pipe(fas, fst), (a) => [a, snd(fas)])
+  }
+}
+
+export function getApply_<S>(S: Semigroup<S>): Apply2C<URI, S> {
+  return {
+    URI,
+    _E: undefined as any,
+    map: map_,
+    ap: ap_(S)
+  }
+}
+
+export function getApplicative_<S>(M: Monoid<S>): Applicative2C<URI, S> {
+  return {
+    ...getApply_(M),
+    of: of(M)
+  }
+}
+
+export function getChain_<S>(S: Semigroup<S>): Chain2C<URI, S> & Apply2C<URI, S> {
+  return {
+    ...getApply_(S),
+    chain: chain_(S)
+  }
+}
+
+export function getMonad_<S>(M: Monoid<S>): Monad2C<URI, S> & Applicative2C<URI, S> {
+  return {
+    ...getChain_(M),
+    of: of(M)
+  }
+}
+
+export function getChainRec_<S>(M: Monoid<S>): ChainRec2C<URI, S> {
+  return {
+    ...getMonad_(M),
+    chainRec: chainRec(M)
+  }
 }

--- a/packages/core/src/Record/index.ts
+++ b/packages/core/src/Record/index.ts
@@ -36,7 +36,25 @@ import type {
   URIS,
   URIS2,
   URIS3,
-  URIS4
+  URIS4,
+  Applicative4EP,
+  Applicative4ECP,
+  Applicative4E,
+  Applicative4EC,
+  Applicative4,
+  Applicative3,
+  Applicative3C,
+  Applicative2,
+  Applicative2C,
+  Applicative1,
+  Applicative,
+  FunctorWithIndex1,
+  Foldable1,
+  TraversableWithIndex1,
+  Compactable1,
+  FilterableWithIndex1,
+  Witherable1,
+  FoldableWithIndex1
 } from "../Base"
 import type { Either } from "../Either"
 import { Eq } from "../Eq"
@@ -907,11 +925,12 @@ export const filter: {
 } = RR.filter
 
 export const filter_: {
-  <A, B extends A>(refinement: Refinement<A, B>): <K extends string>(
-    fa: Record<K, A>
-  ) => Record<K, B>
-  <A>(predicate: Predicate<A>): <K extends string>(fa: Record<K, A>) => Record<K, A>
-} = RR.filter
+  <K extends string, A, B extends A>(
+    fa: Record<K, A>,
+    refinement: Refinement<A, B>
+  ): Record<K, B>
+  <K extends string, A>(fa: Record<K, A>, predicate: Predicate<A>): Record<K, A>
+} = RR.filter_
 
 export const filterMap: {
   <A, B>(f: (a: A) => Option<B>): <K extends string>(fa: Record<K, A>) => Record<K, B>
@@ -1045,4 +1064,374 @@ export const record: CFunctorWithIndex1<URI, string> &
   partitionWithIndex,
   filterMapWithIndex,
   filterWithIndex
+}
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export function traverseWithIndex__<F extends URIS4>(
+  F: Applicative4EP<F>
+): <K extends string, S, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS4, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, S, R, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS4, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, S, R, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS3, E>(
+  F: Applicative3C<F, E>
+): <K extends string, R, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, E, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind2<F, E, B>
+) => Kind2<F, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS2, E>(
+  F: Applicative2C<F, E>
+): <K extends string, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind2<F, E, B>
+) => Kind2<F, E, Record<K, B>>
+export function traverseWithIndex__<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => Kind<F, B>
+) => Kind<F, Record<K, B>>
+export function traverseWithIndex__<F>(
+  F: Applicative<F>
+): <K extends string, A, B>(
+  ta: Record<K, A>,
+  f: (k: K, a: A) => HKT<F, B>
+) => HKT<F, Record<K, B>>
+export function traverseWithIndex__<F>(
+  F: Applicative<F>
+): <A, B>(
+  ta: Record<string, A>,
+  f: (k: string, a: A) => HKT<F, B>
+) => HKT<F, Record<string, B>> {
+  return <A, B>(
+    ta: Record<string, A>,
+    f: (k: string, a: A) => HKT<F, B>
+  ): HKT<F, Record<string, B>> => {
+    const keys = Object.keys(ta)
+    if (keys.length === 0) {
+      return F.of(empty)
+    }
+    let fr: HKT<F, Record<string, B>> = F.of({})
+    for (const key of keys) {
+      fr = F.ap(
+        F.map(fr, (r) => (b: B) => {
+          r[key] = b
+          return r
+        }),
+        f(key, ta[key])
+      )
+    }
+    return fr
+  }
+}
+
+export function traverse__<F extends MaURIS, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, S, R, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function traverse__<F extends MaURIS, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, S, R, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, Record<K, B>>
+export function traverse__<F extends MaURIS>(
+  F: Applicative4EP<F>
+): <K extends string, S, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, unknown, R, E, Record<K, B>>
+export function traverse__<F extends MaURIS>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function traverse__<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, S, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, B>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function traverse__<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, R, E, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, Record<K, B>>
+export function traverse__<F extends URIS3, E>(
+  F: Applicative3C<F, E>
+): <K extends string, R, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind3<F, R, E, B>
+) => Kind3<F, R, E, Record<K, B>>
+export function traverse__<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, E, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind2<F, E, B>
+) => Kind2<F, E, Record<K, B>>
+export function traverse__<F extends URIS2, E>(
+  F: Applicative2C<F, E>
+): <K extends string, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind2<F, E, B>
+) => Kind2<F, E, Record<K, B>>
+export function traverse__<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => Kind<F, B>
+) => Kind<F, Record<K, B>>
+export function traverse__<F>(
+  F: Applicative<F>
+): <K extends string, A, B>(
+  ta: Record<K, A>,
+  f: (a: A) => HKT<F, B>
+) => HKT<F, Record<K, B>>
+export function traverse__<F>(
+  F: Applicative<F>
+): <A, B>(ta: Record<string, A>, f: (a: A) => HKT<F, B>) => HKT<F, Record<string, B>> {
+  const traverseWithIndexF = traverseWithIndex__(F)
+  return (fa, f) => traverseWithIndexF(fa, (_, a) => f(a))
+}
+
+export const wilt__: {
+  <F extends MaURIS, E>(F: Applicative4ECP<F, E>): <K extends string, A, S, R, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, unknown, R, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends MaURIS>(F: Applicative4EP<F>): <K extends string, A, S, R, E, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, unknown, R, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends MaURIS, E>(F: Applicative4EC<F, E>): <K extends string, A, S, R, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, S, R, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends MaURIS>(F: Applicative4E<F>): <K extends string, A, S, R, E, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, S, R, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends URIS4>(F: Applicative4<F>): <K extends string, A, S, R, E, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind4<F, S, R, E, Either<B, C>>
+  ) => Kind4<F, S, R, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends URIS3>(F: Applicative3<F>): <K extends string, A, R, E, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind3<F, R, E, Either<B, C>>
+  ) => Kind3<F, R, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends URIS3, E>(F: Applicative3C<F, E>): <K extends string, A, R, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind3<F, R, E, Either<B, C>>
+  ) => Kind3<F, R, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends URIS2>(F: Applicative2<F>): <K extends string, A, E, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind2<F, E, Either<B, C>>
+  ) => Kind2<F, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends URIS2, E>(F: Applicative2C<F, E>): <K extends string, A, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind2<F, E, Either<B, C>>
+  ) => Kind2<F, E, Separated<Record<K, B>, Record<K, C>>>
+  <F extends URIS>(F: Applicative1<F>): <K extends string, A, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => Kind<F, Either<B, C>>
+  ) => Kind<F, Separated<Record<K, B>, Record<K, C>>>
+  <F>(F: Applicative<F>): <K extends string, A, B, C>(
+    wa: Record<K, A>,
+    f: (a: A) => HKT<F, Either<B, C>>
+  ) => HKT<F, Separated<Record<K, B>, Record<K, C>>>
+} = <F>(
+  F: Applicative<F>
+): (<A, B, C>(
+  wa: Record<string, A>,
+  f: (a: A) => HKT<F, Either<B, C>>
+) => HKT<F, Separated<Record<string, B>, Record<string, C>>>) => {
+  const traverseF = traverse__(F)
+  return (wa, f) => F.map(traverseF(wa, f), separate)
+}
+
+export function sequence_<F extends URIS4, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, S, R, A>(
+  ta: Record<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, S, R, E, Record<K, A>>
+export function sequence_<F extends URIS4, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, S, R, A>(
+  ta: Record<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, unknown, R, E, Record<K, A>>
+export function sequence_<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A>(
+  ta: Record<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, S, R, E, Record<K, A>>
+export function sequence_<F extends URIS4>(
+  F: Applicative4EP<F>
+): <K extends string, S, R, E, A>(
+  ta: Record<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, unknown, R, E, Record<K, A>>
+export function sequence_<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, S, R, E, A>(
+  ta: Record<K, Kind4<F, S, R, E, A>>
+) => Kind4<F, S, R, E, Record<K, A>>
+export function sequence_<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, R, E, A>(
+  ta: Record<K, Kind3<F, R, E, A>>
+) => Kind3<F, R, E, Record<K, A>>
+export function sequence_<F extends URIS3, E>(
+  F: Applicative3C<F, E>
+): <K extends string, R, A>(
+  ta: Record<K, Kind3<F, R, E, A>>
+) => Kind3<F, R, E, Record<K, A>>
+export function sequence_<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, E, A>(ta: Record<K, Kind2<F, E, A>>) => Kind2<F, E, Record<K, A>>
+export function sequence_<F extends URIS2, E>(
+  F: Applicative2C<F, E>
+): <K extends string, A>(ta: Record<K, Kind2<F, E, A>>) => Kind2<F, E, Record<K, A>>
+export function sequence_<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A>(ta: Record<K, Kind<F, A>>) => Kind<F, Record<K, A>>
+export function sequence_<F>(
+  F: Applicative<F>
+): <K extends string, A>(ta: Record<K, HKT<F, A>>) => HKT<F, Record<K, A>>
+export function sequence_<F>(
+  F: Applicative<F>
+): <A>(ta: Record<string, HKT<F, A>>) => HKT<F, Record<string, A>> {
+  return (ta) => traverseWithIndex__(F)(ta, (_, a) => a)
+}
+
+export function wither__<F extends URIS4>(
+  F: Applicative4EP<F>
+): <K extends string, A, S, R, E, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, unknown, R, E, Record<K, B>>
+export function wither__<F extends URIS4, E>(
+  F: Applicative4ECP<F, E>
+): <K extends string, A, S, R, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, unknown, R, E, Record<K, B>>
+export function wither__<F extends URIS4, E>(
+  F: Applicative4EC<F, E>
+): <K extends string, A, S, R, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function wither__<F extends URIS4>(
+  F: Applicative4E<F>
+): <K extends string, A, S, R, E, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function wither__<F extends URIS4>(
+  F: Applicative4<F>
+): <K extends string, A, S, R, E, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind4<F, S, R, E, Option<B>>
+) => Kind4<F, S, R, E, Record<K, B>>
+export function wither__<F extends URIS3>(
+  F: Applicative3<F>
+): <K extends string, A, R, E, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind3<F, R, E, Option<B>>
+) => Kind3<F, R, E, Record<K, B>>
+export function wither__<F extends URIS2>(
+  F: Applicative2<F>
+): <K extends string, A, E, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind2<F, E, Option<B>>
+) => Kind2<F, E, Record<K, B>>
+export function wither__<F extends URIS>(
+  F: Applicative1<F>
+): <K extends string, A, B>(
+  wa: Record<K, A>,
+  f: (a: A) => Kind<F, Option<B>>
+) => Kind<F, Record<K, B>>
+export function wither__<F>(
+  F: Applicative<F>
+): <K extends string, A, B>(
+  wa: Record<K, A>,
+  f: (a: A) => HKT<F, Option<B>>
+) => HKT<F, Record<K, B>> {
+  const traverseF = traverse__(F)
+  return (wa, f) => F.map(traverseF(wa, f), compact)
+}
+
+export const record_: FunctorWithIndex1<URI, string> &
+  Foldable1<URI> &
+  TraversableWithIndex1<URI, string> &
+  Compactable1<URI> &
+  FilterableWithIndex1<URI, string> &
+  Witherable1<URI> &
+  FoldableWithIndex1<URI, string> = {
+  URI,
+  map: map_,
+  reduce: reduce_,
+  foldMap: foldMap_,
+  reduceRight: reduceRight_,
+  traverse: traverse__,
+  sequence: sequence_,
+  compact,
+  separate,
+  filter: filter_,
+  filterMap: filterMap_,
+  partition: partition_,
+  partitionMap: partitionMap_,
+  wither: wither__,
+  wilt: wilt__,
+  mapWithIndex: RR.mapWithIndex_,
+  reduceWithIndex: reduceWithIndex_,
+  foldMapWithIndex: foldMapWithIndex_,
+  reduceRightWithIndex: reduceRightWithIndex_,
+  traverseWithIndex: traverseWithIndex__,
+  partitionMapWithIndex: partitionMapWithIndex_,
+  partitionWithIndex: partitionWithIndex_,
+  filterMapWithIndex: filterMapWithIndex_,
+  filterWithIndex: filterWithIndex_
 }

--- a/packages/core/src/Stream/index.ts
+++ b/packages/core/src/Stream/index.ts
@@ -2,7 +2,7 @@
 
 import * as AP from "../Apply"
 import * as A from "../Array"
-import type { CMonad4MA, CApplicative4MAP } from "../Base"
+import type { CMonad4MA, CApplicative4MAP, Monad4EP } from "../Base"
 import type { ATypeOf, ETypeOf, RTypeOf, STypeOf } from "../Base/Apply"
 import { Deferred, makeDeferred } from "../Deferred"
 import * as D from "../Do"
@@ -1833,3 +1833,16 @@ export const wiltOption =
 export const wiltOption_ =
   /*#__PURE__*/
   (() => O.wilt_(stream))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const stream_: Monad4EP<URI> = {
+  URI,
+  _CTX: "async",
+  map: map_,
+  of,
+  ap: ap_,
+  chain: chain_
+}

--- a/packages/core/src/StreamEither/index.ts
+++ b/packages/core/src/StreamEither/index.ts
@@ -1,7 +1,7 @@
 /* adapted from https://github.com/gcanti/fp-ts-contrib */
 
 import * as A from "../Array"
-import type { CBifunctor4, CMonad4MA, CApplicative4MAP } from "../Base"
+import type { CBifunctor4, CMonad4MA, CApplicative4MAP, Monad4EP } from "../Base"
 import * as AP from "../Base/Apply"
 import * as D from "../Do"
 import * as T from "../Effect"
@@ -524,3 +524,16 @@ export const wiltOption =
 export const wiltOption_ =
   /*#__PURE__*/
   (() => O.wilt_(streamEither))()
+
+//
+// Compatibility with fp-ts ecosystem
+//
+
+export const streamEither_: Monad4EP<URI> = {
+  URI,
+  _CTX: "async",
+  map: map_,
+  of,
+  ap: ap_,
+  chain: chain_
+}


### PR DESCRIPTION
Bring back compatibility like:
```ts
import { sequenceT } from "fp-ts/lib/Apply";
import * as T from "@matechs/core/Effect";
import * as A from "@matechs/core/Array";

sequenceT(T.effect_)(T.pure(0), T.pure(1));
sequenceT(A.array_)(A.range(0, 10), A.range(10, 20));
```