### PR TITLE
#273  Add some tests and fix issue (breaking)

### DIFF
--- a/packages/core/src/Effect/index.ts
+++ b/packages/core/src/Effect/index.ts
@@ -602,7 +602,7 @@ export const filterOrElse: {
 } = <E, A>(predicate: Predicate<A>, onFalse: (a: A) => E) => <S, R>(
   ma: Effect<S, R, E, A>
 ): Effect<S, R, E, A> =>
-  chain_(ma, (a) => (predicate(a) ? completed(raise(onFalse(a))) : completed(done(a))))
+  chain_(ma, (a) => (predicate(a) ? completed(done(a)) : completed(raise(onFalse(a)))))
 
 export const fromPredicate: {
   <E, A, B extends A>(refinement: Refinement<A, B>, onFalse: (a: A) => E): (

--- a/packages/core/src/Managed/index.ts
+++ b/packages/core/src/Managed/index.ts
@@ -481,8 +481,8 @@ export const filterOrElse: {
 ): Managed<S, R, E, A> =>
   chain_(ma, (a) =>
     predicate(a)
-      ? encaseEffect(T.completed(raise(onFalse(a))))
-      : encaseEffect(T.completed(done(a)))
+      ? encaseEffect(T.completed(done(a)))
+      : encaseEffect(T.completed(raise(onFalse(a))))
   )
 
 export const flatten: <S1, S2, R, E, R2, E2, A>(

--- a/packages/core/test/Effect.test.ts
+++ b/packages/core/test/Effect.test.ts
@@ -1259,4 +1259,41 @@ describe("effectify", () => {
     const effFun = T.effectify(fun)
     assert.deepStrictEqual(await T.runToPromiseExit(effFun("x")), ex.raise("error"))
   })
+
+  it("should filterOrElse with predicate true", () => {
+    const gt10 = (n: number): boolean => n > 10
+    const subjectFunction: (
+      _: T.SyncE<string, number>
+    ) => T.SyncE<string, number> = T.filterOrElse(gt10, (n) => `invalid ${n}`)
+
+    const resource: T.SyncE<string, number> = T.pure(12)
+    const result = T.runSync(subjectFunction(resource))
+
+    assert.deepStrictEqual(result, ex.done(12))
+  })
+
+  it("should filterOrElse with predicate false", () => {
+    const gt10 = (n: number): boolean => n > 10
+    const subjectFunction: (
+      _: T.SyncE<string, number>
+    ) => T.SyncE<string, number> = T.filterOrElse(gt10, (n) => `invalid ${n}`)
+
+    const resource: T.SyncE<string, number> = T.pure(7)
+
+    const result = T.runSync(subjectFunction(resource))
+
+    assert.deepStrictEqual(result, ex.raise(`invalid 7`))
+  })
+
+  it("should filterOrElse propagate raised error", () => {
+    const gt10 = (n: number): boolean => n > 10
+    const subjectFunction: (
+      _: T.SyncE<string, number>
+    ) => T.SyncE<string, number> = T.filterOrElse(gt10, (n) => `invalid ${n}`)
+
+    const resource: T.SyncE<string, number> = T.raiseError(`Nope`)
+    const result = T.runSync(subjectFunction(resource))
+
+    assert.deepStrictEqual(result, ex.raise(`Nope`))
+  })
 })


### PR DESCRIPTION
This commit changes `filterOrElse` for `Managed` and `Effect` such that the logic agrees with `filterOrElse` for `Either`: When the predicate returns true, we continue in the successful branch in all three cases, otherwise we switch to the error branch.