### PR TITLE
Add literal union

### DIFF
--- a/packages/core/src/Eq/index.ts
+++ b/packages/core/src/Eq/index.ts
@@ -38,6 +38,15 @@ export function getMonoid<A>(): Monoid<Eq<A>> {
   }
 }
 
+export function getOrMonoid<A>(): Monoid<Eq<A>> {
+  return {
+    concat: (x, y) => fromEquals((a, b) => x.equals(a, b) || y.equals(a, b)),
+    empty: {
+      equals: () => false
+    }
+  }
+}
+
 export function getStructEq<O extends Record<string, any>>(
   eqs: {
     [K in keyof O]: Eq<O[K]>

--- a/packages/morphic-alg/src/primitives/index.ts
+++ b/packages/morphic-alg/src/primitives/index.ts
@@ -17,10 +17,23 @@ export type UUID = Branded<string, UUIDBrand>
 
 export type Keys = Record<string, null>
 
+// Flexible Branded types. Alternative to Const from fp-ts.
+// Found here: https://spin.atomicobject.com/2018/01/15/typescript-flexible-nominal-typing/
+interface Flavoring<B> {
+  _flavourType?: B
+}
+export type Flavor<A, B> = A & Flavoring<B>
+
 export interface LiteralBrand {
   readonly Literal: unique symbol
 }
-export type Literal<A> = Branded<A, LiteralBrand>
+export type Literal<A> = Flavor<A, LiteralBrand>
+export interface NonLiteralBrand {
+  readonly NonLiteral: unique symbol
+}
+export type NonLiteral<A> = Flavor<A, NonLiteralBrand>
+export type LiteralExtract<T> = T extends Literal<infer R> ? R : T
+
 export type LiteralT = string | number
 
 export const PrimitiveURI = "@matechs/morphic-alg/PrimitiveURI" as const
@@ -95,8 +108,8 @@ export interface MatechsAlgebraPrimitive<F, Env> {
   number: {
     (config?: {
       name?: string
-      conf?: ConfigsForType<Env, number, number, NumberConfig>
-    }): HKT2<F, Env, number, number>
+      conf?: ConfigsForType<Env, number, NonLiteral<number>, NumberConfig>
+    }): HKT2<F, Env, number, NonLiteral<number>>
   }
   bigint: {
     (config?: {
@@ -107,8 +120,8 @@ export interface MatechsAlgebraPrimitive<F, Env> {
   string: {
     (config?: {
       name?: string
-      conf?: ConfigsForType<Env, string, string, StringConfig>
-    }): HKT2<F, Env, string, string>
+      conf?: ConfigsForType<Env, string, NonLiteral<string>, StringConfig>
+    }): HKT2<F, Env, string, NonLiteral<string>>
   }
   stringLiteral: {
     <T extends string>(
@@ -250,16 +263,16 @@ export interface MatechsAlgebraPrimitive1<F extends URIS, Env extends AnyEnv> {
   }): Kind<F, Env, boolean>
   number(config?: {
     name?: string
-    conf?: ConfigsForType<Env, number, number, NumberConfig>
-  }): Kind<F, Env, number>
+    conf?: ConfigsForType<Env, number, NonLiteral<number>, NumberConfig>
+  }): Kind<F, Env, NonLiteral<number>>
   bigint(config?: {
     name?: string
     conf?: ConfigsForType<Env, string, bigint, BigIntConfig>
   }): Kind<F, Env, bigint>
   string(config?: {
     name?: string
-    conf?: ConfigsForType<Env, string, string, StringConfig>
-  }): Kind<F, Env, string>
+    conf?: ConfigsForType<Env, string, NonLiteral<string>, StringConfig>
+  }): Kind<F, Env, NonLiteral<string>>
   stringLiteral: <T extends string>(
     value: T,
     config?: {
@@ -379,16 +392,16 @@ export interface MatechsAlgebraPrimitive2<F extends URIS2, Env extends AnyEnv> {
   }): Kind2<F, Env, boolean, boolean>
   number(config?: {
     name?: string
-    conf?: ConfigsForType<Env, number, number, NumberConfig>
-  }): Kind2<F, Env, number, number>
+    conf?: ConfigsForType<Env, number, NonLiteral<number>, NumberConfig>
+  }): Kind2<F, Env, number, NonLiteral<number>>
   bigint(config?: {
     name?: string
     conf?: ConfigsForType<Env, string, bigint, BigIntConfig>
   }): Kind2<F, Env, string, bigint>
   string(config?: {
     name?: string
-    conf?: ConfigsForType<Env, string, string, StringConfig>
-  }): Kind2<F, Env, string, string>
+    conf?: ConfigsForType<Env, string, NonLiteral<string>, StringConfig>
+  }): Kind2<F, Env, string, NonLiteral<string>>
   stringLiteral: <T extends string>(
     value: T,
     config?: {

--- a/packages/morphic-alg/src/primitives/index.ts
+++ b/packages/morphic-alg/src/primitives/index.ts
@@ -21,6 +21,7 @@ export interface LiteralBrand {
   readonly Literal: unique symbol
 }
 export type Literal<A> = Branded<A, LiteralBrand>
+export type LiteralT = string | number
 
 export const PrimitiveURI = "@matechs/morphic-alg/PrimitiveURI" as const
 
@@ -45,6 +46,7 @@ export interface MutableConfig<L, A> {}
 export interface OptionalConfig<L, A> {}
 export interface StringLiteralConfig<T> {}
 export interface NumberLiteralConfig<T> {}
+export interface OneOfLiteralsConfig<T> {}
 export interface KeysOfConfig<K> {}
 export interface EitherConfig<EE, EA, AE, AA> {}
 export interface OptionConfig<L, A> {}
@@ -125,6 +127,20 @@ export interface MatechsAlgebraPrimitive<F, Env> {
         conf?: ConfigsForType<Env, number, Literal<T>, NumberLiteralConfig<Literal<T>>>
       }
     ): HKT2<F, Env, number, Literal<T>>
+  }
+  oneOfLiterals: {
+    <T extends readonly [LiteralT, ...LiteralT[]]>(
+      value: { [k in keyof T]: HKT2<F, Env, LiteralT, Literal<T[k]>> },
+      config?: {
+        name?: string
+        conf?: ConfigsForType<
+          Env,
+          LiteralT,
+          Literal<T[number]>,
+          OneOfLiteralsConfig<Literal<T[number]>>
+        >
+      }
+    ): HKT2<F, Env, LiteralT, Literal<T[number]>>
   }
   keysOf: {
     <K extends Keys>(
@@ -258,6 +274,20 @@ export interface MatechsAlgebraPrimitive1<F extends URIS, Env extends AnyEnv> {
       conf?: ConfigsForType<Env, number, Literal<T>, NumberLiteralConfig<Literal<T>>>
     }
   ) => Kind<F, Env, Literal<T>>
+  oneOfLiterals: {
+    <T extends readonly [LiteralT, ...LiteralT[]]>(
+      value: { [k in keyof T]: Kind<F, Env, Literal<T[k]>> },
+      config?: {
+        name?: string
+        conf?: ConfigsForType<
+          Env,
+          LiteralT,
+          Literal<T[number]>,
+          OneOfLiteralsConfig<Literal<T[number]>>
+        >
+      }
+    ): Kind<F, Env, Literal<T[number]>>
+  }
   keysOf: <K extends Keys>(
     keys: K,
     config?: {
@@ -373,6 +403,20 @@ export interface MatechsAlgebraPrimitive2<F extends URIS2, Env extends AnyEnv> {
       conf?: ConfigsForType<Env, number, Literal<T>, NumberLiteralConfig<Literal<T>>>
     }
   ) => Kind2<F, Env, number, Literal<T>>
+  oneOfLiterals: {
+    <T extends readonly [LiteralT, ...LiteralT[]]>(
+      value: { [k in keyof T]: Kind2<F, Env, LiteralT, Literal<T[k]>> },
+      config?: {
+        name?: string
+        conf?: ConfigsForType<
+          Env,
+          LiteralT,
+          Literal<T[number]>,
+          OneOfLiteralsConfig<Literal<T[number]>>
+        >
+      }
+    ): Kind2<F, Env, LiteralT, Literal<T[number]>>
+  }
   keysOf: <K extends Keys>(
     keys: K,
     config?: {

--- a/packages/morphic-alg/src/primitives/index.ts
+++ b/packages/morphic-alg/src/primitives/index.ts
@@ -17,6 +17,11 @@ export type UUID = Branded<string, UUIDBrand>
 
 export type Keys = Record<string, null>
 
+export interface LiteralBrand {
+  readonly Literal: unique symbol
+}
+export type Literal<A> = Branded<A, LiteralBrand>
+
 export const PrimitiveURI = "@matechs/morphic-alg/PrimitiveURI" as const
 
 export type PrimitiveURI = typeof PrimitiveURI
@@ -108,18 +113,18 @@ export interface MatechsAlgebraPrimitive<F, Env> {
       value: T,
       config?: {
         name?: string
-        conf?: ConfigsForType<Env, string, T, StringLiteralConfig<T>>
+        conf?: ConfigsForType<Env, string, Literal<T>, StringLiteralConfig<Literal<T>>>
       }
-    ): HKT2<F, Env, string, typeof value>
+    ): HKT2<F, Env, string, Literal<T>>
   }
   numberLiteral: {
     <T extends number>(
       value: T,
       config?: {
         name?: string
-        conf?: ConfigsForType<Env, number, T, NumberLiteralConfig<T>>
+        conf?: ConfigsForType<Env, number, Literal<T>, NumberLiteralConfig<Literal<T>>>
       }
-    ): HKT2<F, Env, number, typeof value>
+    ): HKT2<F, Env, number, Literal<T>>
   }
   keysOf: {
     <K extends Keys>(
@@ -243,16 +248,16 @@ export interface MatechsAlgebraPrimitive1<F extends URIS, Env extends AnyEnv> {
     value: T,
     config?: {
       name?: string
-      conf?: ConfigsForType<Env, string, T, StringLiteralConfig<T>>
+      conf?: ConfigsForType<Env, string, Literal<T>, StringLiteralConfig<Literal<T>>>
     }
-  ) => Kind<F, Env, typeof value>
+  ) => Kind<F, Env, Literal<T>>
   numberLiteral: <T extends number>(
     value: T,
     config?: {
       name?: string
-      conf?: ConfigsForType<Env, number, T, NumberLiteralConfig<T>>
+      conf?: ConfigsForType<Env, number, Literal<T>, NumberLiteralConfig<Literal<T>>>
     }
-  ) => Kind<F, Env, typeof value>
+  ) => Kind<F, Env, Literal<T>>
   keysOf: <K extends Keys>(
     keys: K,
     config?: {
@@ -358,16 +363,16 @@ export interface MatechsAlgebraPrimitive2<F extends URIS2, Env extends AnyEnv> {
     value: T,
     config?: {
       name?: string
-      conf?: ConfigsForType<Env, string, T, StringLiteralConfig<T>>
+      conf?: ConfigsForType<Env, string, Literal<T>, StringLiteralConfig<Literal<T>>>
     }
-  ) => Kind2<F, Env, string, typeof value>
+  ) => Kind2<F, Env, string, Literal<T>>
   numberLiteral: <T extends number>(
     value: T,
     config?: {
       name?: string
-      conf?: ConfigsForType<Env, number, T, NumberLiteralConfig<T>>
+      conf?: ConfigsForType<Env, number, Literal<T>, NumberLiteralConfig<Literal<T>>>
     }
-  ) => Kind2<F, Env, number, typeof value>
+  ) => Kind2<F, Env, number, Literal<T>>
   keysOf: <K extends Keys>(
     keys: K,
     config?: {

--- a/packages/morphic-alg/src/tagged-union/index.ts
+++ b/packages/morphic-alg/src/tagged-union/index.ts
@@ -1,4 +1,5 @@
 import type { ConfigsForType, AnyEnv } from "../config"
+import type { LiteralExtract } from "../primitives"
 import type { URIS, Kind, URIS2, Kind2, HKT2 } from "../utils/hkt"
 
 export const TaggedUnionsURI = "@matechs/morphic-alg/TaggedUnionsURI" as const
@@ -35,6 +36,10 @@ type DecorateTag<
 
 export interface TaggedUnionConfig<Types> {}
 
+export type ExtractTagLiteral<A, Tag> = {
+  [k in keyof A]: k extends Tag ? LiteralExtract<A[k]> : A[k]
+}
+
 export interface MatechsAlgebraTaggedUnions<F, Env> {
   _F: F
   taggedUnion: {
@@ -46,7 +51,7 @@ export interface MatechsAlgebraTaggedUnions<F, Env> {
         conf?: ConfigsForType<
           Env,
           Types[keyof Types]["_E"],
-          Types[keyof Types]["_A"],
+          ExtractTagLiteral<Types[keyof Types]["_A"], Tag>,
           TaggedUnionConfig<Types>
         >
       }

--- a/packages/morphic/src/adt/ctors/index.ts
+++ b/packages/morphic/src/adt/ctors/index.ts
@@ -1,17 +1,20 @@
 import type { Remove, ExtractUnion, KeysDefinition, Tagged } from "../utils"
 
 import { mapWithIndex } from "@matechs/core/Record"
+import { LiteralExtract } from "@matechs/morphic-alg/primitives"
 
 export type CtorType<C extends Ctors<any, any>> = C extends Ctors<infer A, any>
   ? A
   : never
 
 export type Of<A, Tag extends keyof A> = {
-  [key in A[Tag] & string]: (a: Remove<ExtractUnion<A, Tag, key>, Tag>) => A
+  [key in LiteralExtract<A[Tag]> & string]: (
+    a: Remove<ExtractUnion<A, Tag, key>, Tag>
+  ) => A
 }
 
 export type As<A, Tag extends keyof A> = {
-  [key in A[Tag] & string]: (
+  [key in LiteralExtract<A[Tag]> & string]: (
     a: Remove<ExtractUnion<A, Tag, key>, Tag>
   ) => ExtractUnion<A, Tag, key>
 }
@@ -21,6 +24,7 @@ export interface Ctors<A, Tag extends keyof A & string> {
   of: Of<A, Tag>
   as: As<A, Tag>
   make: (a: A) => A
+  // make: (a: { [k in keyof A]: k extends Tag ? LiteralExtract<A[k]> : A[k] }) => A
 }
 
 export const Ctors = <A extends Tagged<Tag>, Tag extends string>(tag: Tag) => (

--- a/packages/morphic/src/adt/index.ts
+++ b/packages/morphic/src/adt/index.ts
@@ -14,16 +14,17 @@ import {
 import { eqString } from "@matechs/core/Eq"
 import { tuple, identity } from "@matechs/core/Function"
 import { fromFoldable } from "@matechs/core/Record"
+import { LiteralExtract } from "@matechs/morphic-alg/primitives"
 
 export interface ADT<A, Tag extends keyof A & string>
   extends Ma.Matchers<A, Tag>,
     PU.Predicates<A, Tag>,
     CtorsWithKeys<A, Tag>,
     M.MonocleFor<A> {
-  select: <Keys extends A[Tag][]>(
+  select: <Keys extends LiteralExtract<A[Tag]>[]>(
     keys: Keys
   ) => ADT<ExtractUnion<A, Tag, ElemType<Keys>>, Tag>
-  exclude: <Keys extends A[Tag][]>(
+  exclude: <Keys extends LiteralExtract<A[Tag]>[]>(
     keys: Keys
   ) => ADT<ExcludeUnion<A, Tag, ElemType<Keys>>, Tag>
 }
@@ -106,7 +107,7 @@ export const makeADT = <Tag extends string>(tag: Tag) => <
   type Tag = typeof tag
   type A = TypeOfDef<R[keyof R]>
   type B = A & Tagged<Tag>
-  const keys = _keys as KeysDefinition<Tagged<Tag>, Tag> // any
+  const keys = (_keys as unknown) as KeysDefinition<Tagged<Tag>, Tag> // any
 
   const ctors = CU.Ctors(tag)(keys)
   const predicates = PU.Predicates<A, Tag>(tag)(keys)

--- a/packages/morphic/src/adt/predicates/index.ts
+++ b/packages/morphic/src/adt/predicates/index.ts
@@ -1,13 +1,14 @@
 import type { ExtractUnion, ElemType, KeysDefinition } from "../utils"
 
 import { mapWithIndex } from "@matechs/core/Record"
+import { LiteralExtract } from "@matechs/morphic-alg/primitives"
 
 export type Is<A, Tag extends keyof A> = {
-  [key in A[Tag] & string]: (a: A) => a is ExtractUnion<A, Tag, key>
+  [key in LiteralExtract<A[Tag]> & string]: (a: A) => a is ExtractUnion<A, Tag, key>
 }
 
 export interface IsAny<A, Tag extends keyof A> {
-  <Keys extends A[Tag][]>(keys: Keys): (
+  <Keys extends LiteralExtract<A[Tag]>[]>(keys: Keys): (
     a: A
   ) => a is ExtractUnion<A, Tag, ElemType<Keys>>
 }

--- a/packages/morphic/src/adt/utils/index.ts
+++ b/packages/morphic/src/adt/utils/index.ts
@@ -1,3 +1,5 @@
+import { LiteralExtract } from "@matechs/morphic-alg/primitives"
+
 export type Remove<A, Tag> = { [k in Exclude<keyof A, Tag>]: A[k] }
 
 export type ElemType<A> = A extends Array<infer E> ? E : never
@@ -13,7 +15,7 @@ export type ExcludeUnion<A, Tag extends keyof A, Tags extends A[Tag]> = Exclude<
 >
 
 export type KeysDefinition<A, Tag extends keyof A> = {
-  [k in A[Tag] & string]: any
+  [k in LiteralExtract<A[Tag]> & string]: any
 }
 
 export type Tagged<Tag extends string> = { [t in Tag]: string }

--- a/packages/morphic/src/batteries/usage/tagged-union/index.ts
+++ b/packages/morphic/src/batteries/usage/tagged-union/index.ts
@@ -15,7 +15,8 @@ import {
 import { ConfigsForType } from "@matechs/morphic-alg/config"
 import type {
   TaggedUnionsURI,
-  TaggedUnionConfig
+  TaggedUnionConfig,
+  ExtractTagLiteral
 } from "@matechs/morphic-alg/tagged-union"
 import type { HKT2, Algebra } from "@matechs/morphic-alg/utils/hkt"
 
@@ -90,7 +91,7 @@ export type TaggedBuilder<
     conf?: ConfigsForType<
       R,
       Types[keyof Types]["_E"],
-      Types[keyof Types]["_A"],
+      ExtractTagLiteral<Types[keyof Types]["_A"], Tag>,
       TaggedUnionConfig<Types>
     >
   }

--- a/packages/morphic/src/eq/interpreter/primitives.ts
+++ b/packages/morphic/src/eq/interpreter/primitives.ts
@@ -8,7 +8,11 @@ import { contramap_, eqBoolean, eqNumber, eqStrict, eqString } from "@matechs/co
 import { introduce } from "@matechs/core/Function"
 import { getEq as OgetEq } from "@matechs/core/Option"
 import type { AnyEnv } from "@matechs/morphic-alg/config"
-import type { MatechsAlgebraPrimitive1, UUID } from "@matechs/morphic-alg/primitives"
+import type {
+  Literal,
+  MatechsAlgebraPrimitive1,
+  UUID
+} from "@matechs/morphic-alg/primitives"
 
 export const eqPrimitiveInterpreter = memo(
   <Env extends AnyEnv>(): MatechsAlgebraPrimitive1<EqURI, Env> => ({
@@ -26,9 +30,9 @@ export const eqPrimitiveInterpreter = memo(
     bigint: (config) => (env) =>
       new EqType<bigint>(eqApplyConfig(config?.conf)(eqStrict, env, {})),
     stringLiteral: (k, config) => (env) =>
-      new EqType<typeof k>(eqApplyConfig(config?.conf)(eqString, env, {})),
+      new EqType<Literal<typeof k>>(eqApplyConfig(config?.conf)(eqString, env, {})),
     numberLiteral: (k, config) => (env) =>
-      new EqType<typeof k>(eqApplyConfig(config?.conf)(eqNumber, env, {})),
+      new EqType<Literal<typeof k>>(eqApplyConfig(config?.conf)(eqNumber, env, {})),
     keysOf: (keys, config) => (env) =>
       new EqType<keyof typeof keys & string>(
         eqApplyConfig(config?.conf)(eqStrict, env, {})

--- a/packages/morphic/src/fc/interpreter/primitives.ts
+++ b/packages/morphic/src/fc/interpreter/primitives.ts
@@ -2,7 +2,7 @@ import { memo } from "../../utils"
 import { fcApplyConfig, accessFC } from "../config"
 import { FastCheckType, FastCheckURI } from "../hkt"
 
-import { isNonEmpty } from "@matechs/core/Array"
+import { isNonEmpty, map_ } from "@matechs/core/Array"
 import { left, right } from "@matechs/core/Either"
 import { introduce } from "@matechs/core/Function"
 import { fromNullable, none, some } from "@matechs/core/Option"
@@ -43,6 +43,14 @@ export const fcPrimitiveInterpreter = memo(
       new FastCheckType(
         fcApplyConfig(config?.conf)(
           accessFC(env).constant(l as Literal<typeof l>),
+          env,
+          {}
+        )
+      ),
+    oneOfLiterals: (ls, config) => (env) =>
+      new FastCheckType(
+        fcApplyConfig(config?.conf)(
+          accessFC(env).oneof(...map_(ls, (l) => l(env).arb)),
           env,
           {}
         )

--- a/packages/morphic/src/fc/interpreter/primitives.ts
+++ b/packages/morphic/src/fc/interpreter/primitives.ts
@@ -7,7 +7,7 @@ import { left, right } from "@matechs/core/Either"
 import { introduce } from "@matechs/core/Function"
 import { fromNullable, none, some } from "@matechs/core/Option"
 import type { AnyEnv } from "@matechs/morphic-alg/config"
-import type { MatechsAlgebraPrimitive1 } from "@matechs/morphic-alg/primitives"
+import type { Literal, MatechsAlgebraPrimitive1 } from "@matechs/morphic-alg/primitives"
 
 export const fcPrimitiveInterpreter = memo(
   <Env extends AnyEnv>(): MatechsAlgebraPrimitive1<FastCheckURI, Env> => ({
@@ -33,11 +33,19 @@ export const fcPrimitiveInterpreter = memo(
       new FastCheckType(fcApplyConfig(config?.conf)(accessFC(env).bigInt(), env, {})),
     stringLiteral: (l, config) => (env) =>
       new FastCheckType(
-        fcApplyConfig(config?.conf)(accessFC(env).constant(l), env, {})
+        fcApplyConfig(config?.conf)(
+          accessFC(env).constant(l as Literal<typeof l>),
+          env,
+          {}
+        )
       ),
     numberLiteral: (l, config) => (env) =>
       new FastCheckType(
-        fcApplyConfig(config?.conf)(accessFC(env).constant(l), env, {})
+        fcApplyConfig(config?.conf)(
+          accessFC(env).constant(l as Literal<typeof l>),
+          env,
+          {}
+        )
       ),
     keysOf: (k, config) => (env) =>
       new FastCheckType(

--- a/packages/morphic/src/guard/interpreter/common.ts
+++ b/packages/morphic/src/guard/interpreter/common.ts
@@ -1,5 +1,7 @@
 import type { Guard } from "../hkt"
 
+import type { Monoid } from "@matechs/core/Monoid"
+
 export const isUnknownRecord = (u: unknown): u is { [key: string]: unknown } => {
   const s = Object.prototype.toString.call(u)
   return s === "[object Object]" || s === "[object Window]"
@@ -10,3 +12,10 @@ export const isString = (u: unknown): u is string => typeof u === "string"
 export const isNumber = (u: unknown): u is number => typeof u === "number"
 
 export type AOfGuard<X extends Guard<any>> = X extends Guard<infer A> ? A : never
+
+export function getOrGuard<A>(): Monoid<Guard<A>> {
+  return {
+    concat: (x, y) => ({ is: (u: unknown): u is A => x.is(u) || y.is(u) }),
+    empty: { is: (u: unknown): u is A => false }
+  }
+}

--- a/packages/morphic/src/guard/interpreter/primitives.ts
+++ b/packages/morphic/src/guard/interpreter/primitives.ts
@@ -10,7 +10,11 @@ import { introduce } from "@matechs/core/Function"
 import type { NonEmptyArray } from "@matechs/core/NonEmptyArray"
 import type { Option } from "@matechs/core/Option"
 import type { AnyEnv } from "@matechs/morphic-alg/config"
-import type { MatechsAlgebraPrimitive1, UUID } from "@matechs/morphic-alg/primitives"
+import type {
+  Literal,
+  MatechsAlgebraPrimitive1,
+  UUID
+} from "@matechs/morphic-alg/primitives"
 
 export const regexUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -68,19 +72,21 @@ export const guardPrimitiveInterpreter = memo(
         )
       ),
     stringLiteral: (k, config) => (env) =>
-      new GuardType<typeof k>(
+      new GuardType(
         guardApplyConfig(config?.conf)(
           {
-            is: (u): u is typeof k => isString(u) && u === k
+            is: (u): u is Literal<typeof k> => isString(u) && u === k
           },
           env,
           {}
         )
       ),
     numberLiteral: (k, config) => (env) =>
-      new GuardType<typeof k>(
+      new GuardType(
         guardApplyConfig(config?.conf)(
-          { is: (u): u is typeof k => isNumber(u) && u === k },
+          {
+            is: (u): u is Literal<typeof k> => isNumber(u) && u === k
+          },
           env,
           {}
         )

--- a/packages/morphic/src/model/interpreter/primitives.ts
+++ b/packages/morphic/src/model/interpreter/primitives.ts
@@ -5,7 +5,7 @@ import { ModelType, ModelURI } from "../hkt"
 
 import { introduce } from "@matechs/core/Function"
 import type { AnyEnv } from "@matechs/morphic-alg/config"
-import type { MatechsAlgebraPrimitive2 } from "@matechs/morphic-alg/primitives"
+import type { Literal, MatechsAlgebraPrimitive2 } from "@matechs/morphic-alg/primitives"
 
 export const modelPrimitiveInterpreter = memo(
   <Env extends AnyEnv>(): MatechsAlgebraPrimitive2<ModelURI, Env> => ({
@@ -40,11 +40,19 @@ export const modelPrimitiveInterpreter = memo(
       ),
     stringLiteral: (l, config) => (env) =>
       new ModelType(
-        modelApplyConfig(config?.conf)(M.literal(l, config?.name || l), env, {})
+        modelApplyConfig(config?.conf)(
+          M.literal(l as Literal<typeof l>, config?.name || l),
+          env,
+          {}
+        )
       ),
     numberLiteral: (l, config) => (env) =>
       new ModelType(
-        modelApplyConfig(config?.conf)(M.literal(l, config?.name || `${l}`), env, {})
+        modelApplyConfig(config?.conf)(
+          M.literal(l as Literal<typeof l>, config?.name || `${l}`),
+          env,
+          {}
+        )
       ),
     keysOf: (k, config) => (env) =>
       new ModelType(

--- a/packages/morphic/src/show/interpreter/primitives.ts
+++ b/packages/morphic/src/show/interpreter/primitives.ts
@@ -13,6 +13,7 @@ import type { AnyEnv, ConfigsForType } from "@matechs/morphic-alg/config"
 import type {
   Keys,
   KeysOfConfig,
+  Literal,
   MatechsAlgebraPrimitive1,
   NumberLiteralConfig,
   StringLiteralConfig,
@@ -54,11 +55,11 @@ export const showPrimitiveInterpreter = memo(
       _: T,
       config?: {
         name?: string
-        conf?: ConfigsForType<Env, string, T, StringLiteralConfig<T>>
+        conf?: ConfigsForType<Env, string, Literal<T>, StringLiteralConfig<Literal<T>>>
       }
     ) => (env) =>
       new ShowType(
-        introduce<Show<T>>({
+        introduce<Show<Literal<T>>>({
           show: (t) => showString.show(t)
         })((show) => showApplyConfig(config?.conf)(named(config?.name)(show), env, {}))
       ),
@@ -66,11 +67,11 @@ export const showPrimitiveInterpreter = memo(
       _: T,
       config?: {
         name?: string
-        conf?: ConfigsForType<Env, number, T, NumberLiteralConfig<T>>
+        conf?: ConfigsForType<Env, number, Literal<T>, NumberLiteralConfig<Literal<T>>>
       }
     ) => (env) =>
       new ShowType(
-        introduce<Show<T>>({
+        introduce<Show<Literal<T>>>({
           show: (t) => showNumber.show(t)
         })((show) => showApplyConfig(config?.conf)(named(config?.name)(show), env, {}))
       ),

--- a/packages/morphic/src/show/interpreter/primitives.ts
+++ b/packages/morphic/src/show/interpreter/primitives.ts
@@ -5,7 +5,7 @@ import { ShowType, ShowURI } from "../hkt"
 
 import { getShow as AgetShow } from "@matechs/core/Array"
 import { getShow as EgetShow } from "@matechs/core/Either"
-import { introduce } from "@matechs/core/Function"
+import { absurd, introduce } from "@matechs/core/Function"
 import { getShow as OgetShow } from "@matechs/core/Option"
 import { showBoolean, showNumber, showString } from "@matechs/core/Show"
 import type { Show } from "@matechs/core/Show"
@@ -14,6 +14,7 @@ import type {
   Keys,
   KeysOfConfig,
   Literal,
+  LiteralT,
   MatechsAlgebraPrimitive1,
   NumberLiteralConfig,
   StringLiteralConfig,
@@ -73,6 +74,17 @@ export const showPrimitiveInterpreter = memo(
       new ShowType(
         introduce<Show<Literal<T>>>({
           show: (t) => showNumber.show(t)
+        })((show) => showApplyConfig(config?.conf)(named(config?.name)(show), env, {}))
+      ),
+    oneOfLiterals: (_, config) => (env) =>
+      new ShowType(
+        introduce<Show<LiteralT>>({
+          show: (t: LiteralT) =>
+            typeof t === "string"
+              ? showString.show(t)
+              : typeof t === "number"
+              ? showNumber.show(t)
+              : absurd(t)
         })((show) => showApplyConfig(config?.conf)(named(config?.name)(show), env, {}))
       ),
     keysOf: <K extends Keys>(

--- a/packages/morphic/src/utils/index.ts
+++ b/packages/morphic/src/utils/index.ts
@@ -1,6 +1,8 @@
 import type { Array } from "@matechs/core/Array"
 import * as R from "@matechs/core/Record"
 
+export { LiteralExtract } from "@matechs/morphic-alg/primitives"
+
 export const mapRecord = <Dic extends { [k in keyof Dic]: any }, B>(
   d: Dic,
   f: (v: Dic[keyof Dic]) => B

--- a/packages/morphic/test/Morphic.test.ts
+++ b/packages/morphic/test/Morphic.test.ts
@@ -1,6 +1,7 @@
 import * as fc from "fast-check"
 
 import * as M from "../src"
+import { isIn } from "../src/adt/utils"
 import * as EQ from "../src/eq"
 import * as FC from "../src/fc"
 import * as GUARD from "../src/guard"
@@ -207,6 +208,63 @@ const TaggedADT = M.makeADT("_tag")(
     }
   }
 )
+
+function typeLevelTest() {
+  const zx = M.make((F) =>
+    F.oneOfLiterals([F.stringLiteral("hi"), F.stringLiteral("bye")], {
+      conf: {
+        [M.ShowURI]: (_s, _e, _c) => ({ show: (a) => _s.show(a) })
+      }
+    })
+  )
+
+  const zz00 = TaggedADT
+  const zz01 = TaggedADT._Types
+  const zz02 = TaggedADT.select(["left"])
+  const zz03 = TaggedADT.exclude(["left"])
+  const zz11 = TaggedADT.tag
+  const zz12 = TaggedADT.of.left({ value: "hi" })
+  const zz13 = TaggedADT.as.left({ value: "hi" })
+  const zz14 = TaggedADT.make({ _tag: "left", value: "hi" })
+  const zz15 = TaggedADT.keys
+  type T = keyof typeof TaggedADT["keys"]
+  const xzx2 = isIn(zz15)("left")
+  const xzx = zz15.left
+  const zz21 = TaggedADT.transform({ left: (v) => v })
+  const zz22 = TaggedADT.fold((v) => (v._tag === "left" ? T.pure(v.value) : T.never))
+  const zz23 = TaggedADT.match({ left: (v) => T.unit, right: (v) => T.unit })
+  const zz24 = TaggedADT.matchStrict({ left: (v) => T.unit, right: (v) => T.unit })
+  const zz25 = TaggedADT.createReducer("")({
+    left: (v) => (s) => s,
+    right: (v) => (s) => s
+  })("hi", TaggedADT.of.left({ value: "hi" }))
+  const zz26 = TaggedADT.strict((v) => (v._tag === "left" ? v._tag : v.value))
+  if (TaggedADT.is.left(zz12)) {
+    const zz30 = zz12._tag
+  }
+  const zz31 = TaggedADT.verified(zz12)
+  if (TaggedADT.isAnyOf(["left"])(zz12)) {
+    const zz32 = zz12._tag
+  }
+
+  const zz40 = TaggedADT.lensFromProp("_tag")
+  const zz50 = TaggedADT.build({ _tag: "left", value: "hi" })
+  const zz60 = M.make((F) => F.array(TaggedADT(F)))
+  const zz61 = EQ.derive(TaggedADT)
+  const zz62 = TaggedADT.selectMorph(["left"], {
+    conf: {
+      [M.EqURI]: (_s, _e, _c) => _s
+    }
+  })
+
+  const x = TaggedADT.match({ left: (v) => T.unit, right: (v) => T.unit })
+  type y = { _tag: "left"; value: number } | { _tag: "right"; right: boolean }
+  declare const z: y
+  if (z._tag === "left") {
+    const xxx = z.value
+  } else {
+  }
+}
 
 const SubADT = TaggedADT.selectMorph(["left"], {
   conf: {

--- a/packages_inc/cqrs-es/src/index.ts
+++ b/packages_inc/cqrs-es/src/index.ts
@@ -17,6 +17,7 @@ import { ElemType } from "@matechs/morphic/adt/utils"
 import { InterpreterURI } from "@matechs/morphic/batteries/interpreter"
 import { ProgramURI } from "@matechs/morphic/batteries/usage/program-type"
 import { AOfTypes } from "@matechs/morphic/batteries/usage/tagged-union"
+import { LiteralExtract } from "@matechs/morphic/utils"
 
 const aggregateRead = <
   Types extends {
@@ -25,7 +26,7 @@ const aggregateRead = <
   Tag extends string,
   ProgURI extends ProgramURI,
   InterpURI extends InterpreterURI,
-  Keys extends NEA.NonEmptyArray<keyof Types>,
+  Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>,
   Db extends symbol | string,
   Env
 >(
@@ -42,7 +43,7 @@ export const aggregate = <
   Tag extends string,
   ProgURI extends ProgramURI,
   InterpURI extends InterpreterURI,
-  Keys extends NEA.NonEmptyArray<keyof Types>,
+  Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>,
   Db extends symbol | string,
   Env
 >(

--- a/packages_inc/cqrs/src/aggregate.ts
+++ b/packages_inc/cqrs/src/aggregate.ts
@@ -22,6 +22,7 @@ import {
   AOfTypes,
   AOfMorhpADT
 } from "@matechs/morphic/batteries/usage/tagged-union"
+import type { LiteralExtract } from "@matechs/morphic/utils"
 import { DbT, DbTx, ORM, TaskError } from "@matechs/orm"
 
 // experimental alpha
@@ -31,12 +32,12 @@ export type Handler<S, A, R, E, B> = (a: A) => T.Effect<S, R, E, B>
 
 export class Aggregate<
   Types extends {
-    [k in keyof Types]: [any, any]
+    [k in LiteralExtract<keyof Types>]: [any, any]
   },
   Tag extends string,
   ProgURI extends ProgramURI,
   InterpURI extends InterpreterURI,
-  Keys extends NEA.NonEmptyArray<keyof Types>,
+  Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>,
   Db extends symbol | string,
   Env
 > {
@@ -57,7 +58,7 @@ export class Aggregate<
   }
 
   private readonly narrowADT: MorphADT<
-    { [k in Extract<keyof Types, keyof Types>]: Types[k] },
+    { [k in Extract<keyof Types, LiteralExtract<keyof Types>>]: Types[k] },
     Tag,
     ProgURI,
     InterpURI,
@@ -65,7 +66,7 @@ export class Aggregate<
   > = this.S.selectMorph(A.toMutable(this.eventTypes))
 
   adt: MorphADT<
-    { [k in Extract<keyof Types, keyof Types>]: Types[k] },
+    { [k in Extract<keyof Types, LiteralExtract<keyof Types>>]: Types[k] },
     Tag,
     ProgURI,
     InterpURI,
@@ -106,7 +107,9 @@ export class Aggregate<
   }
 
   readOnly(config: ReadSideConfig) {
-    return <Keys2 extends NEA.NonEmptyArray<keyof Types>>(eventTypes: Keys2) =>
+    return <Keys2 extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>>(
+      eventTypes: Keys2
+    ) =>
       this.read.readSide(config)(
         new SliceFetcher(this.S, eventTypes, this.db).fetchSlice(this.aggregate),
         eventTypes
@@ -132,12 +135,12 @@ type InferR<
 
 export class AggregateRoot<
   Types extends {
-    [k in keyof Types]: [any, any]
+    [k in LiteralExtract<keyof Types>]: [any, any]
   },
   Tag extends string,
   ProgURI extends ProgramURI,
   InterpURI extends InterpreterURI,
-  Keys extends NEA.NonEmptyArray<keyof Types>,
+  Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>,
   Db extends symbol | string,
   H extends Array<
     Handler<

--- a/packages_inc/cqrs/src/domain.ts
+++ b/packages_inc/cqrs/src/domain.ts
@@ -11,6 +11,7 @@ import * as NEA from "@matechs/core/NonEmptyArray"
 import { InterpreterURI } from "@matechs/morphic/batteries/usage/interpreter-result"
 import { ProgramURI } from "@matechs/morphic/batteries/usage/program-type"
 import { MorphADT, AOfMorhpADT } from "@matechs/morphic/batteries/usage/tagged-union"
+import { LiteralExtract } from "@matechs/morphic/utils"
 import { dbT } from "@matechs/orm"
 
 // experimental alpha
@@ -51,7 +52,7 @@ export class Domain<
     matchEffect: matcher(this.S)
   }
 
-  aggregate<Keys extends NEA.NonEmptyArray<keyof Types>>(
+  aggregate<Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>>(
     aggregate: string,
     eventTypes: Keys
   ) {
@@ -69,7 +70,9 @@ export class Domain<
   }
 
   readOnly(config: ReadSideConfig) {
-    return <Keys extends NEA.NonEmptyArray<keyof Types>>(eventTypes: Keys) =>
+    return <Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>>(
+      eventTypes: Keys
+    ) =>
       this.read.readSide(config)(
         new DomainFetcher(this.S, eventTypes, this.db).fetchSlice(),
         eventTypes

--- a/packages_inc/cqrs/src/fetchSlice.ts
+++ b/packages_inc/cqrs/src/fetchSlice.ts
@@ -9,6 +9,7 @@ import { InterpreterURI } from "@matechs/morphic/batteries/usage/interpreter-res
 import { ProgramURI } from "@matechs/morphic/batteries/usage/program-type"
 import { MorphADT, AOfTypes } from "@matechs/morphic/batteries/usage/tagged-union"
 import * as t from "@matechs/morphic/model"
+import type { LiteralExtract } from "@matechs/morphic/utils"
 import { DbT } from "@matechs/orm"
 
 // experimental alpha
@@ -21,7 +22,7 @@ export class SliceFetcher<
   Tag extends string,
   ProgURI extends ProgramURI,
   InterpURI extends InterpreterURI,
-  Keys extends NEA.NonEmptyArray<keyof Types>,
+  Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>,
   Db extends symbol | string,
   Env
 > {
@@ -112,7 +113,7 @@ export class AggregateFetcher<
   Tag extends string,
   ProgURI extends ProgramURI,
   InterpURI extends InterpreterURI,
-  Keys extends NEA.NonEmptyArray<keyof Types>,
+  Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>,
   Db extends symbol | string,
   Env
 > {
@@ -199,7 +200,7 @@ export class DomainFetcher<
   Tag extends string,
   ProgURI extends ProgramURI,
   InterpURI extends InterpreterURI,
-  Keys extends NEA.NonEmptyArray<keyof Types>,
+  Keys extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>,
   Db extends symbol | string,
   Env
 > {

--- a/packages_inc/cqrs/src/read.ts
+++ b/packages_inc/cqrs/src/read.ts
@@ -17,6 +17,7 @@ import { ElemType } from "@matechs/morphic/adt/utils"
 import { InterpreterURI } from "@matechs/morphic/batteries/usage/interpreter-result"
 import { ProgramURI } from "@matechs/morphic/batteries/usage/program-type"
 import { MorphADT, AOfTypes } from "@matechs/morphic/batteries/usage/tagged-union"
+import type { LiteralExtract } from "@matechs/morphic/utils"
 import { DbT, ORM, TaskError } from "@matechs/orm"
 
 // experimental alpha
@@ -61,7 +62,7 @@ export class Read<
     )
 
   readSide(config: ReadSideConfig) {
-    return <Keys2 extends NEA.NonEmptyArray<keyof Types>>(
+    return <Keys2 extends NEA.NonEmptyArray<LiteralExtract<keyof Types>>>(
       fetchEvents: T.AsyncRE<
         ORM<Db> & ReadSideConfigService,
         TaskError,


### PR DESCRIPTION
progress so far.

There is some weirdness with ADT: it seems that ADT constructor needs to be able to unpack `Literal<T>` brand.

Also, I added `getOrMonoid` in `@matechs/core/Eq`. If its a bad idea, i'll move it somewhere else.