### PR TITLE
Include peerDependencies in copied package.json

### DIFF
--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -50,6 +50,7 @@ pipe(
           repository: content["repository"],
           sideEffects: content["sideEffects"],
           dependencies: content["dependencies"],
+          peerDependencies: content["peerDependencies"],
           gitHead: content["gitHead"],
           main: "./index.js",
           module: "./esm/index.js",


### PR DESCRIPTION
Just noticed that `@matechs/tracing` was missing peer dependencies in the published bundle (even though they were declared in source)