### PR TITLE
Allow adding extra tags into span

### DIFF
--- a/packages_be/tracing/src/Tracing/index.ts
+++ b/packages_be/tracing/src/Tracing/index.ts
@@ -263,11 +263,19 @@ export function withChildSpan(operation: string) {
     T.accessM((r: R) => (hasTracer(r) ? r[TracerURI].withChildSpan(operation)(ma) : ma))
 }
 
+/**
+ * Add tags into a current span. Note: tags have to be added before wrapping an
+ * effect with `withControllerSpan` or `withChildSpan` calls.
+ */
 export function addSpanTags(extraTags: Record<string, unknown>) {
   return <S, R, E, A>(ma: T.Effect<S, R, E, A>): T.Effect<S, R, E, A> =>
     T.accessM((r: R) => (hasTracer(r) ? r[TracerURI].addSpanTags(extraTags)(ma) : ma))
 }
 
+/**
+ * Set tag with key into a current span. Note: the tag has to be added before
+ * wrapping an effect with `withControllerSpan` or `withChildSpan` calls.
+ */
 export function setSpanTag(key: string, value: unknown) {
   return <S, R, E, A>(ma: T.Effect<S, R, E, A>): T.Effect<S, R, E, A> =>
     T.accessM((r: R) => (hasTracer(r) ? r[TracerURI].setSpanTag(key, value)(ma) : ma))

--- a/packages_be/tracing/test/demo/Counter.ts
+++ b/packages_be/tracing/test/demo/Counter.ts
@@ -1,4 +1,4 @@
-import { withChildSpan } from "../../src"
+import { withChildSpan, addSpanTags } from "../../src"
 
 import { print, Printer } from "./Printer"
 
@@ -53,7 +53,14 @@ export const Counter = L.fromValue<Counter>({
         T.traverseArray((n) =>
           T.Do()
             .do(increment())
-            .bind("count", withChildSpan("span-current-count")(currentCount()))
+            .bind(
+              "count",
+              pipe(
+                currentCount(),
+                addSpanTags({ "some.tag": "tag value" }),
+                withChildSpan("span-current-count")
+              )
+            )
             .doL(({ count }) => print(`n: ${n} (${count})`))
             .unit()
         )


### PR DESCRIPTION
This allows addition of extra tags to span.

I'm uncertain about current implementation. Currently, the code first adds tags into span and then executes the target effect:

```typescript
pipe(
  T.sync(() => {
    const span = r[SpanContext].spanInstance
    for (const [k, v] of Object.entries(extraTags)) {
      span.setTag(k, v)
    }
  }),
  T.apSecond(ma)
)
```

Should this be other way around?

Also, it is unclear to me to which span the tags will apply between these two cases:
```typescript
pipe(
  T.unit,
  withExtraTags({ name: "hello" }),
  withChildSpan("operation")
)
```
and 
```typescript
pipe(
  T.unit,
  withChildSpan("operation"),
  withExtraTags({ name: "hello" })
)
```