### PR TITLE
guard against nullable value

### DIFF
--- a/packages_be/tracing/src/Tracing/index.ts
+++ b/packages_be/tracing/src/Tracing/index.ts
@@ -112,7 +112,9 @@ function runWithSpan<S, R, E, A>(
             span.setTag(
               EXTRA_TAGS.ERROR_MESSAGE,
               JSON.stringify(e, (_, value) =>
-                typeof value.toJSON !== "function" && value instanceof Error
+                value != null &&
+                typeof value.toJSON !== "function" &&
+                value instanceof Error
                   ? value.toString()
                   : value
               )


### PR DESCRIPTION
I noticed that trace sometimes causes an unexpected crash because of an unchecked property access on `undefined`/`null` values