### PR TITLE
Allow effectful jest mock acquisition

### DIFF
--- a/packages/test-jest/src/Aspects/WithJestMocks/index.ts
+++ b/packages/test-jest/src/Aspects/WithJestMocks/index.ts
@@ -1,5 +1,4 @@
 import * as T from "@matechs/core/Effect"
-import { Lazy } from "@matechs/core/Function"
 import { pipe } from "@matechs/core/Function"
 import * as M from "@matechs/test"
 import { Spec } from "@matechs/test/Def"
@@ -22,15 +21,15 @@ export const useMockM = <Mocks extends MockT<Mocks>>() => <S, R, E, A>(
   op: (_: Mocks) => T.Effect<S, R, E, A>
 ) => T.accessM((_: JestMocks<Mocks>) => _[JestMocksURI].useMockM(op))
 
-export const mockedTestM = (name: string) => <Mocks extends MockT<Mocks>>(
-  acquire: Lazy<Mocks>
+export const mockedTestM = (name: string) => <S1, R1, E1, Mocks extends MockT<Mocks>>(
+  acquire: T.Effect<S1, R1, E1, Mocks>
 ) => <R, E, A>(
   eff: (_: {
     useMockM: <S, R, E, A>(
       op: (_: Mocks) => T.Effect<S, R, E, A>
     ) => T.Effect<S, R & JestMocks<Mocks>, E, A>
   }) => T.Effect<unknown, R & JestMocks<Mocks>, E, A>
-): Spec<R> =>
+): Spec<R1 & R> =>
   pipe(
     M.testM(
       name,
@@ -40,7 +39,7 @@ export const mockedTestM = (name: string) => <Mocks extends MockT<Mocks>>(
     ),
     M.withHookP(
       pipe(
-        T.sync(acquire),
+        acquire,
         T.map(
           (_): JestMocks<Mocks> => ({
             [JestMocksURI]: {

--- a/packages/test-jest/test/root.test.ts
+++ b/packages/test-jest/test/root.test.ts
@@ -12,10 +12,12 @@ run(
 
 run(
   suite("jest mock")(
-    mockedTestM("test using mocked console")(() => ({
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      info: jest.spyOn(console, "info").mockImplementation(() => {})
-    }))(({ useMockM }) =>
+    mockedTestM("test using mocked console")(
+      T.sync(() => ({
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        info: jest.spyOn(console, "info").mockImplementation(() => {})
+      }))
+    )(({ useMockM }) =>
       T.Do()
         .do(
           T.sync(() => {

--- a/packages_sys/logger-pino/test/Pino.test.ts
+++ b/packages_sys/logger-pino/test/Pino.test.ts
@@ -38,9 +38,11 @@ const checkLevel = <O extends object>(
   )
 
 const pinoLoggerSpec = M.suite("Pino")(
-  M.mockedTestM("use pino logger instance")(() => ({
-    write: jest.fn<void, [string]>(empty)
-  }))(({ useMockM }) =>
+  M.mockedTestM("use pino logger instance")(
+    T.sync(() => ({
+      write: jest.fn<void, [string]>(empty)
+    }))
+  )(({ useMockM }) =>
     pipe(
       T.Do()
         .do(P.fatal({ foo: "bar" }, "msg"))
@@ -98,9 +100,11 @@ const pinoLoggerSpec = M.suite("Pino")(
       }))
     )
   ),
-  M.mockedTestM("use @matechs/logger instance")(() => ({
-    write: jest.fn<void, [string]>(empty)
-  }))(({ useMockM }) =>
+  M.mockedTestM("use @matechs/logger instance")(
+    T.sync(() => ({
+      write: jest.fn<void, [string]>(empty)
+    }))
+  )(({ useMockM }) =>
     T.Do()
       .do(L.logger.info("ok"))
       .do(L.logger.http("ok"))

--- a/packages_sys/logger/test/Logger.test.ts
+++ b/packages_sys/logger/test/Logger.test.ts
@@ -12,12 +12,14 @@ const empty = () => {}
 const Logger = ConsoleLogger.with(ConsoleLoggerConfig())
 
 const loggerSpec = M.suite("Logger")(
-  M.mockedTestM("use logger")(() => ({
-    info: jest.spyOn(console, "info").mockImplementation(empty),
-    warn: jest.spyOn(console, "warn").mockImplementation(empty),
-    debug: jest.spyOn(console, "debug").mockImplementation(empty),
-    error: jest.spyOn(console, "error").mockImplementation(empty)
-  }))(({ useMockM }) =>
+  M.mockedTestM("use logger")(
+    T.sync(() => ({
+      info: jest.spyOn(console, "info").mockImplementation(empty),
+      warn: jest.spyOn(console, "warn").mockImplementation(empty),
+      debug: jest.spyOn(console, "debug").mockImplementation(empty),
+      error: jest.spyOn(console, "error").mockImplementation(empty)
+    }))
+  )(({ useMockM }) =>
     T.Do()
       .do(L.info("ok"))
       .do(L.http("ok"))
@@ -39,9 +41,11 @@ const loggerSpec = M.suite("Logger")(
       )
       .done()
   ),
-  M.mockedTestM("use logger with level")(() => ({
-    debug: jest.spyOn(console, "debug").mockImplementation(empty)
-  }))(({ useMockM }) =>
+  M.mockedTestM("use logger with level")(
+    T.sync(() => ({
+      debug: jest.spyOn(console, "debug").mockImplementation(empty)
+    }))
+  )(({ useMockM }) =>
     T.Do()
       .do(L.debug("ok"))
       .do(


### PR DESCRIPTION
I'm not sure why mock acquisition was limited to only be `IO`. This extends it to be any effect.