### PR TITLE
BufferedPull pullArray

### DIFF
--- a/packages/system/src/Stream/BufferedPull/index.ts
+++ b/packages/system/src/Stream/BufferedPull/index.ts
@@ -1,8 +1,7 @@
 import * as T from "../_internal/effect"
 import * as A from "../../Array"
-import type * as CC from "../../Cause"
 import * as TT from "../../Effect"
-import { flow, identity, pipe } from "../../Function"
+import { pipe } from "../../Function"
 import * as O from "../../Option"
 import * as R from "../../Ref"
 import * as Pull from "../Pull"
@@ -90,7 +89,7 @@ export const pullArray = <S, R, E, A>(
           if (idx >= chunk.length) {
             return [TT.chain_(update(self), () => pullArray(self)), [[], 0]]
           } else {
-            return [T.as_(update(self), A.dropLeft_(chunk, idx)), [[], 0]]
+            return [T.succeedNow(A.dropLeft_(chunk, idx)), [[], 0]]
           }
         }),
         T.flatten
@@ -105,34 +104,3 @@ export const make = <S, R, E, A>(pull: T.Effect<S, R, O.Option<E>, A.Array<A>>) 
     T.bind("cursor", () => R.makeRef<[A.Array<A>, number]>([[], 0])),
     T.map(({ cursor, done }) => new BufferedPull(pull, done, cursor))
   )
-;(async function main() {
-  const log = <T extends unknown[]>(...x: T): TT.Sync<void> =>
-    TT.effectTotal(() => console.log(...x))
-  await pipe(
-    R.makeRef(0),
-    T.chain(
-      flow(
-        R.modify((i): [TT.SyncE<O.Option<never>, A.Array<number>>, number] => [
-          i < 5 ? TT.succeed([i]) : TT.fail(O.none),
-          i + 1
-        ]),
-        T.flatten,
-        make
-      )
-    ),
-    TT.chain((bp) =>
-      TT.repeatWhile_(
-        ifNotDone(
-          TT.foldM_(
-            pullArray(bp),
-            O.fold(() => TT.zipSecond_(log("finished"), Pull.end), Pull.fail),
-            flow(log, TT.zipSecond(TT.succeed(true)))
-          )
-        )(bp),
-        identity
-      )
-    ),
-    TT.runPromise,
-    (p) => p.catch((e: CC.FiberFailure<unknown>) => console.log("\n\n" + e.pretty))
-  )
-})()

--- a/packages/system/src/Stream/_internal/effect.ts
+++ b/packages/system/src/Stream/_internal/effect.ts
@@ -1,3 +1,4 @@
+export { as_ } from "../../Effect/as"
 export { asSomeError } from "../../Effect/asSomeError"
 export { asUnit } from "../../Effect/asUnit"
 export { bimap } from "../../Effect/bimap"

--- a/packages/system/test/stream.test.ts
+++ b/packages/system/test/stream.test.ts
@@ -1,0 +1,48 @@
+import * as T from "../src/Effect"
+import * as Exit from "../src/Exit"
+import { flow, identity, pipe } from "../src/Function"
+import * as O from "../src/Option"
+import * as R from "../src/Ref"
+import * as BufferedPull from "../src/Stream/BufferedPull"
+import * as Pull from "../src/Stream/Pull"
+
+describe("Stream", () => {
+  describe("BufferedPull", () => {
+    it("pullArray", () => {
+      const program = pipe(
+        R.makeRef(0),
+        T.chain(
+          flow(
+            R.modify((i): [T.SyncE<O.Option<never>, readonly number[]>, number] => [
+              i < 5 ? T.succeed([i]) : T.fail(O.none),
+              i + 1
+            ]),
+            T.flatten,
+            BufferedPull.make
+          )
+        ),
+        T.zip(T.succeed([] as number[])),
+        T.chain(([bp, res]) =>
+          T.catchAll_(
+            T.repeatWhile_(
+              BufferedPull.ifNotDone(
+                T.foldM_(
+                  T.chain_(BufferedPull.pullArray(bp), (a) => {
+                    res.push(...a)
+                    return T.succeed(a)
+                  }),
+                  O.fold(() => Pull.end, Pull.fail),
+                  () => T.succeed(true)
+                )
+              )(bp),
+              identity
+            ),
+            () => T.succeed(res)
+          )
+        )
+      )
+
+      expect(T.runSyncExit(program)).toEqual(Exit.succeed([0, 1, 2, 3, 4]))
+    })
+  })
+})


### PR DESCRIPTION
I believe https://github.com/zio/zio/blob/master/streams/shared/src/main/scala/zio/stream/ZStream.scala#L4002 contains a bug, what is basically going on is when we call `update.as(chunk.drop(idx))` for the last time the `update` will fail (signaling end) de-facto losing the last element. In `pullElement` calling `update` is delegated to the subsequent call