### PR TITLE
Fix Async Fold

### DIFF
--- a/packages/core/src/Async/core.ts
+++ b/packages/core/src/Async/core.ts
@@ -160,7 +160,7 @@ export class IFold<R, E, A, R2, E2, B, R3, E3, C> extends Async<
   E2 | E3,
   B | C
 > {
-  readonly _asyncTag = "ICatch"
+  readonly _asyncTag = "IFold"
 
   constructor(
     readonly self: Async<R, E, A>,
@@ -409,7 +409,7 @@ async function runInternal<R, E, A>(
     case "IProvide": {
       return await runInternal(op.self, op.r, is)
     }
-    case "ICatch": {
+    case "IFold": {
       const a = await runPromiseExitEnv(op.self, r, is)
 
       switch (a._tag) {

--- a/packages/core/src/Async/core.ts
+++ b/packages/core/src/Async/core.ts
@@ -417,7 +417,7 @@ async function runInternal<R, E, A>(
           return await runInternal(op.f(a.e), r, is)
         }
         case "Success": {
-          return a.a
+          return await runInternal(op.g(a.a), r, is)
         }
         case "Interrupt": {
           throw interruptExit

--- a/packages/core/test/async.test.ts
+++ b/packages/core/test/async.test.ts
@@ -23,4 +23,14 @@ describe("Async", () => {
       await As.runPromiseExit(pipe(fib(10), As.provideAll({ initial: 1 })))
     ).toEqual(As.successExit(89))
   })
+  it("fold", async () => {
+    expect(
+      await pipe(
+        As.access((_: { n: number }) => _.n),
+        As.fold(As.fail, (n) => As.succeed(n + 1)),
+        As.provideAll({ n: 1 }),
+        As.runPromiseExit
+      )
+    ).toEqual(As.successExit(2))
+  })
 })


### PR DESCRIPTION
While reading through `Async`, I noticed the third parameter of `IFold` (`g`) was unused in `runInternal`, which was returning the success value from running `self`. Also changed the _asyncTag from `"ICatch"` to `"IFold"` for consistency