### PR TITLE
Fix Async IAll

### DIFF
--- a/packages/core/test/async.test.ts
+++ b/packages/core/test/async.test.ts
@@ -33,4 +33,12 @@ describe("Async", () => {
       )
     ).toEqual(As.successExit(2))
   })
+  it("collectAll", async () => {
+    expect(
+      await pipe(
+        As.collectAll([As.succeed(1), As.succeed(2), As.succeed(3)] as const),
+        As.runPromiseExit
+      )
+    ).toEqual(As.successExit([1, 2, 3]))
+  })
 })

--- a/packages/system/src/Async/core.ts
+++ b/packages/system/src/Async/core.ts
@@ -492,6 +492,9 @@ export function runPromiseExitEnv<R, E, A>(
               }
             }
           }
+          if (!errored) {
+            curAsync = new ISucceed(as)
+          }
           break
         }
         case "Fail": {


### PR DESCRIPTION
`All` instruction block in `runPromiseExitEnv` didn't set `curAsync` on success :)