### PR TITLE
Fix SyncLayer All

### DIFF
--- a/packages/core/src/Sync/Layer/index.ts
+++ b/packages/core/src/Sync/Layer/index.ts
@@ -206,7 +206,7 @@ export class All<Layers extends SyncLayer<any, any, any>[]> extends SyncLayer<
         A.reduce(<Sy.Sync<any, any, any>>Sy.succeed({}), (b, a) =>
           pipe(
             getMemoOrElseCreate(a)(_),
-            Sy.chain((x) => ({ ...b, ...x }))
+            Sy.chain((x) => Sy.map_(b, (k) => ({ ...k, ...x })))
           )
         )
       )


### PR DESCRIPTION
It looks like the `scope` method of `All` in `SyncLayer` was trying to spread a `Sync` instead of the object wrapped inside of it. I haven't done a lot of testing of this fix so I'm not sure how robust it is, but it appears to work as intended!