### PR TITLE
Fix Schedule fixed

### DIFF
--- a/packages/system/src/Schedule/schedule.ts
+++ b/packages/system/src/Schedule/schedule.ts
@@ -813,7 +813,8 @@ export function fixed(interval: number): Schedule<unknown, unknown, number> {
             ),
           ({ lastRun, startMillis }) => {
             const runningBehind = now > lastRun + interval
-            const boundary = (now - startMillis) % interval
+            const boundary =
+              interval === 0 ? interval : interval - ((now - startMillis) % interval)
             const sleepTime = boundary === 0 ? now : boundary
             const nextRun = runningBehind ? now : now + sleepTime
 


### PR DESCRIPTION
While testing `Stream#aggregateAsyncEither` I ran into a little bug in `Schedule#fixed` that caused the `setTimeout` delay to go over the maximum allowed number. This is a fix from what I saw in the [ZIO version of Schedule](https://github.com/zio/zio/blob/c0adc8e86db88678bd776c01a8889d91c4064eb8/core/shared/src/main/scala/zio/Schedule.scala#L986)